### PR TITLE
Add public JSON endpoint for group details and events

### DIFF
--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{Html, IntoResponse},
 };
 use chrono::Duration;
+use serde::Serialize;
 use serde_json::json;
 use tracing::instrument;
 use uuid::Uuid;
@@ -31,6 +32,53 @@ use super::{error::HandlerError, extractors::CommunityId};
 
 #[cfg(test)]
 mod tests;
+
+/// Public JSON payload for group details and events.
+#[derive(Debug, Serialize)]
+struct PublicGroupPayload {
+    group: PublicGroupDetails,
+    upcoming_events: Vec<PublicEventDetails>,
+    past_events: Vec<PublicEventDetails>,
+}
+
+/// Public group details section.
+#[derive(Debug, Serialize)]
+struct PublicGroupDetails {
+    name: String,
+    description: Option<String>,
+    description_short: Option<String>,
+    members_count: i64,
+    organizers: Vec<crate::types::user::User>,
+    social_links: PublicGroupSocialLinks,
+}
+
+/// Public group social links.
+#[derive(Debug, Serialize)]
+struct PublicGroupSocialLinks {
+    website_url: Option<String>,
+    github_url: Option<String>,
+    linkedin_url: Option<String>,
+    twitter_url: Option<String>,
+    slack_url: Option<String>,
+    facebook_url: Option<String>,
+    instagram_url: Option<String>,
+    youtube_url: Option<String>,
+    bluesky_url: Option<String>,
+    flickr_url: Option<String>,
+    wechat_url: Option<String>,
+    extra_links: Option<std::collections::BTreeMap<String, String>>,
+}
+
+/// Public event details section.
+#[derive(Debug, Serialize)]
+struct PublicEventDetails {
+    title: String,
+    starts_at: Option<chrono::DateTime<chrono::Utc>>,
+    ends_at: Option<chrono::DateTime<chrono::Utc>>,
+    location: Option<String>,
+    kind: EventKind,
+    image_url: String,
+}
 
 // Pages handlers.
 
@@ -79,6 +127,72 @@ pub(crate) async fn page(
     let headers = prepare_headers(Duration::hours(1), &[])?;
 
     Ok((headers, Html(template.render()?)))
+}
+
+/// Handler that returns public group details and events as JSON.
+#[instrument(skip_all)]
+pub(crate) async fn page_json(
+    State(db): State<DynDB>,
+    CommunityId(community_id): CommunityId,
+    Path((_, group_slug)): Path<(String, String)>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let event_kinds = vec![EventKind::InPerson, EventKind::Virtual, EventKind::Hybrid];
+    let (group, past_events, upcoming_events) = tokio::try_join!(
+        db.get_group_full_by_slug(community_id, &group_slug),
+        db.get_group_past_events(community_id, &group_slug, event_kinds.clone(), 50),
+        db.get_group_upcoming_events(community_id, &group_slug, event_kinds, 50)
+    )?;
+    let group = group.ok_or(HandlerError::NotFound)?;
+
+    let payload = PublicGroupPayload {
+        group: PublicGroupDetails {
+            name: group.name,
+            description: group.description,
+            description_short: group.description_short,
+            members_count: group.members_count,
+            organizers: group.organizers,
+            social_links: PublicGroupSocialLinks {
+                website_url: group.website_url,
+                github_url: group.github_url,
+                linkedin_url: group.linkedin_url,
+                twitter_url: group.twitter_url,
+                slack_url: group.slack_url,
+                facebook_url: group.facebook_url,
+                instagram_url: group.instagram_url,
+                youtube_url: group.youtube_url,
+                bluesky_url: group.bluesky_url,
+                flickr_url: group.flickr_url,
+                wechat_url: group.wechat_url,
+                extra_links: group.extra_links,
+            },
+        },
+        upcoming_events: upcoming_events
+            .into_iter()
+            .map(|event| PublicEventDetails {
+                title: event.name,
+                starts_at: event.starts_at,
+                ends_at: event.ends_at,
+                location: event.location(500),
+                kind: event.kind,
+                image_url: event.logo_url,
+            })
+            .collect(),
+        past_events: past_events
+            .into_iter()
+            .map(|event| PublicEventDetails {
+                title: event.name,
+                starts_at: event.starts_at,
+                ends_at: event.ends_at,
+                location: event.location(500),
+                kind: event.kind,
+                image_url: event.logo_url,
+            })
+            .collect(),
+    };
+
+    let headers = prepare_headers(Duration::minutes(10), &[])?;
+
+    Ok((headers, Json(payload)))
 }
 
 // Actions handlers.

--- a/ocg-server/src/handlers/group/tests.rs
+++ b/ocg-server/src/handlers/group/tests.rs
@@ -96,6 +96,161 @@ async fn test_page_success() {
 }
 
 #[tokio::test]
+async fn test_page_json_success() {
+    // Setup identifiers and data structures
+    let community_id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_get_community_id_by_name()
+        .times(1)
+        .withf(|name| name == "test-community")
+        .returning(move |_| Ok(Some(community_id)));
+    db.expect_get_group_full_by_slug()
+        .times(1)
+        .withf(move |id, slug| *id == community_id && slug == "test-group")
+        .returning(move |_, _| Ok(Some(sample_group_full(community_id, group_id))));
+    db.expect_get_group_upcoming_events()
+        .times(1)
+        .withf(move |id, slug, kinds, limit| {
+            *id == community_id
+                && slug == "test-group"
+                && kinds == &vec![EventKind::InPerson, EventKind::Virtual, EventKind::Hybrid]
+                && *limit == 50
+        })
+        .returning(move |_, _, _, _| Ok(vec![sample_event_summary(event_id, group_id)]));
+    db.expect_get_group_past_events()
+        .times(1)
+        .withf(move |id, slug, kinds, limit| {
+            *id == community_id
+                && slug == "test-group"
+                && kinds == &vec![EventKind::InPerson, EventKind::Virtual, EventKind::Hybrid]
+                && *limit == 50
+        })
+        .returning(move |_, _, _, _| Ok(vec![sample_event_summary(event_id, group_id)]));
+
+    // Setup notifications manager mock
+    let nm = MockNotificationsManager::new();
+
+    // Setup router and send request
+    let router = TestRouterBuilder::new(db, nm).build().await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/test-community/group/test-group/json")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+
+    // Check response matches expectations
+    assert_eq!(parts.status, StatusCode::OK);
+    assert_eq!(
+        parts.headers.get(CONTENT_TYPE).unwrap(),
+        &HeaderValue::from_static("application/json")
+    );
+    assert_eq!(
+        parts.headers.get(CACHE_CONTROL).unwrap(),
+        &HeaderValue::from_static("max-age=600")
+    );
+    let body: serde_json::Value = from_slice(&bytes).unwrap();
+    assert_eq!(body["group"]["name"], "Test Group");
+    assert_eq!(body["group"]["members_count"], 0);
+    assert_eq!(body["upcoming_events"].as_array().map(Vec::len), Some(1));
+    assert_eq!(body["past_events"].as_array().map(Vec::len), Some(1));
+}
+
+#[tokio::test]
+async fn test_page_json_not_found() {
+    // Setup identifiers and data structures
+    let community_id = Uuid::new_v4();
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_get_community_id_by_name()
+        .times(1)
+        .withf(|name| name == "test-community")
+        .returning(move |_| Ok(Some(community_id)));
+    db.expect_get_group_full_by_slug()
+        .times(1)
+        .withf(move |id, slug| *id == community_id && slug == "missing-group")
+        .returning(move |_, _| Ok(None));
+    db.expect_get_group_upcoming_events()
+        .times(1)
+        .withf(move |id, slug, kinds, limit| {
+            *id == community_id
+                && slug == "missing-group"
+                && kinds == &vec![EventKind::InPerson, EventKind::Virtual, EventKind::Hybrid]
+                && *limit == 50
+        })
+        .returning(move |_, _, _, _| Ok(vec![]));
+    db.expect_get_group_past_events()
+        .times(1)
+        .withf(move |id, slug, kinds, limit| {
+            *id == community_id
+                && slug == "missing-group"
+                && kinds == &vec![EventKind::InPerson, EventKind::Virtual, EventKind::Hybrid]
+                && *limit == 50
+        })
+        .returning(move |_, _, _, _| Ok(vec![]));
+
+    // Setup notifications manager mock
+    let nm = MockNotificationsManager::new();
+
+    // Setup router and send request
+    let router = TestRouterBuilder::new(db, nm).build().await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/test-community/group/missing-group/json")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+
+    // Check response matches expectations
+    assert_eq!(parts.status, StatusCode::NOT_FOUND);
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test]
+async fn test_page_json_db_error() {
+    // Setup identifiers and data structures
+    let community_id = Uuid::new_v4();
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_get_community_id_by_name()
+        .times(1)
+        .withf(|name| name == "test-community")
+        .returning(move |_| Ok(Some(community_id)));
+    db.expect_get_group_full_by_slug()
+        .times(1)
+        .withf(move |id, slug| *id == community_id && slug == "test-group")
+        .returning(move |_, _| Err(anyhow!("db error")));
+
+    // Setup notifications manager mock
+    let nm = MockNotificationsManager::new();
+
+    // Setup router and send request
+    let router = TestRouterBuilder::new(db, nm).build().await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/test-community/group/test-group/json")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+
+    // Check response matches expectations
+    assert_eq!(parts.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test]
 async fn test_page_not_found() {
     // Setup identifiers and data structures
     let community_id = Uuid::new_v4();

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -203,6 +203,7 @@ pub(crate) async fn setup(
         // Community-prefixed public routes
         .route("/{community}", get(community::page))
         .route("/{community}/group/{group_slug}", get(group::page))
+        .route("/{community}/group/{group_slug}/json", get(group::page_json))
         .route("/{community}/event/{event_id}/cfs-modal", get(event::cfs_modal))
         .route(
             "/{community}/group/{group_slug}/event/{event_slug}/availability",


### PR DESCRIPTION
## Summary
Adds a public, read-only JSON endpoint for community group pages:

- `GET /{community}/group/{group_slug}/json`

This endpoint is intended for external community/chapter websites that need stable programmatic access to group data without scraping HTML.

## What this includes
- New handler returning:
  - Group details: name, description, short description, members count, organizers, social links
  - Upcoming events: title, starts/ends time, location, kind, image URL
  - Past events: same fields as upcoming
- Route wiring in the public community group routes
- Handler tests for:
  - success
  - not found
  - database error

## Files changed
- `ocg-server/src/handlers/group.rs`
- `ocg-server/src/router.rs`
- `ocg-server/src/handlers/group/tests.rs`

## Testing
- Added unit tests in `ocg-server/src/handlers/group/tests.rs`.
- Local execution of `cargo test` was not possible in this environment because Rust toolchain (`cargo`) is unavailable in this terminal; CI should run the full Rust checks on PR.
