### PR TITLE
ci(build-images): declare contents: read

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -12,6 +12,11 @@ env:
   OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
   OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
 
+# OCIR push uses OCI_AUTH_TOKEN + OCI_CLI_* secrets; default GITHUB_TOKEN
+# only needs read for the checkout.
+permissions:
+  contents: read
+
 jobs:
   build-ocg-dbmigrator-image:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `build-images.yml`. All three build jobs (dbmigrator/redirector/server) push to OCIR via `secrets.OCI_AUTH_TOKEN` + `OCI_CLI_*` secrets, so the default token is only used for the checkout.

YAML validated locally.