### PR TITLE
Improve cancel event attendance experience

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -84,6 +84,7 @@
 {{ template "dashboard-group/add_event_series.sql" }}
 {{ template "dashboard-group/add_group_sponsor.sql" }}
 {{ template "dashboard-group/add_group_team_member.sql" }}
+{{ template "dashboard-group/cancel_event_attendee_attendance.sql" }}
 {{ template "dashboard-group/cancel_event_attendee_invitation.sql" }}
 {{ template "dashboard-group/cancel_event.sql" }}
 {{ template "dashboard-group/cancel_event_series_events.sql" }}

--- a/database/migrations/functions/dashboard-group/cancel_event_attendee_attendance.sql
+++ b/database/migrations/functions/dashboard-group/cancel_event_attendee_attendance.sql
@@ -1,0 +1,105 @@
+-- Cancels a confirmed event attendance from the group dashboard.
+create or replace function cancel_event_attendee_attendance(
+    p_actor_user_id uuid,
+    p_group_id uuid,
+    p_event_id uuid,
+    p_user_id uuid
+) returns json as $$
+declare
+    v_capacity int;
+    v_community_id uuid;
+    v_is_ticketed boolean;
+    v_promoted_user_ids uuid[] := array[]::uuid[];
+    v_purchase_amount_minor bigint;
+    v_purchase_id uuid;
+begin
+    -- Lock the event and verify it belongs to the selected group and can be changed
+    select
+        e.capacity,
+        g.community_id,
+        exists(
+            select 1
+            from event_ticket_type ett
+            where ett.event_id = e.event_id
+        )
+    into
+        v_capacity,
+        v_community_id,
+        v_is_ticketed
+    from event e
+    join "group" g using (group_id)
+    where e.event_id = p_event_id
+    and e.group_id = p_group_id
+    and e.deleted = false
+    and e.published = true
+    and e.canceled = false
+    and (
+        coalesce(e.ends_at, e.starts_at) is null
+        or coalesce(e.ends_at, e.starts_at) >= current_timestamp
+    )
+    for update of e;
+
+    if not found then
+        raise exception 'event not found or inactive';
+    end if;
+
+    -- Paid attendees must go through the refund workflow
+    select
+        ep.amount_minor,
+        ep.event_purchase_id
+    into
+        v_purchase_amount_minor,
+        v_purchase_id
+    from event_purchase ep
+    where ep.event_id = p_event_id
+    and ep.user_id = p_user_id
+    and ep.status in ('completed', 'refund-requested')
+    order by ep.created_at desc, ep.event_purchase_id desc
+    limit 1;
+
+    if v_purchase_amount_minor > 0 then
+        raise exception 'paid attendees cannot be canceled from attendee actions';
+    end if;
+
+    -- Remove only confirmed attendees
+    delete from event_attendee
+    where event_id = p_event_id
+    and user_id = p_user_id
+    and status = 'confirmed';
+
+    if not found then
+        raise exception 'confirmed event attendee not found';
+    end if;
+
+    -- If the attendee had a free ticket purchase, delegate the refund transition
+    if v_purchase_id is not null then
+        perform refund_free_event_purchase(v_purchase_id);
+    end if;
+
+    -- Promote the next waitlisted user when a confirmed attendee frees a seat
+    if not v_is_ticketed then
+        select promote_event_waitlist(
+            p_event_id,
+            case when v_capacity is null then null else 1 end
+        )
+        into v_promoted_user_ids;
+    end if;
+
+    -- Track the cancellation
+    perform insert_audit_log(
+        'event_attendee_attendance_canceled',
+        p_actor_user_id,
+        'user',
+        p_user_id,
+        v_community_id,
+        p_group_id,
+        p_event_id,
+        jsonb_build_object('event_id', p_event_id, 'user_id', p_user_id)
+    );
+
+    return json_build_object(
+        'left_status', 'attendee',
+        'promoted_user_ids', v_promoted_user_ids
+    );
+end;
+$$ language plpgsql;

--- a/database/migrations/functions/dashboard-group/list_group_audit_logs.sql
+++ b/database/migrations/functions/dashboard-group/list_group_audit_logs.sql
@@ -22,6 +22,7 @@ returns json as $$
             and al.action = any(array[
                 'cfs_submission_updated',
                 'event_added',
+                'event_attendee_attendance_canceled',
                 'event_attendee_checked_in',
                 'event_attendee_invitation_accepted',
                 'event_attendee_invitation_canceled',

--- a/database/migrations/functions/dashboard-user/list_user_events.sql
+++ b/database/migrations/functions/dashboard-user/list_user_events.sql
@@ -144,6 +144,16 @@ returns json as $$
             select coalesce(
                 json_agg(
                     json_build_object(
+                        'can_cancel_attendance',
+                        event_rows_page.roles = array['Attendee'::text]
+                        and not exists (
+                            select 1
+                            from event_purchase ep
+                            where ep.event_id = event_rows_page.event_id
+                            and ep.user_id = p_user_id
+                            and ep.status in ('completed', 'refund-requested')
+                            and ep.amount_minor > 0
+                        ),
                         'event',
                         get_event_summary(
                             event_rows_page.community_id,

--- a/database/migrations/functions/notifications/enqueue_due_event_reminders.sql
+++ b/database/migrations/functions/notifications/enqueue_due_event_reminders.sql
@@ -2,10 +2,13 @@
 create or replace function enqueue_due_event_reminders(p_base_url text)
 returns int as $$
 declare
+    v_attendee_recipients uuid[];
     v_base_url text;
     v_event record;
-    v_recipients uuid[];
+    v_recipient_count int;
     v_reminders_enqueued int := 0;
+    v_speaker_only_recipients uuid[];
+    v_template_data jsonb;
 begin
     -- Ensure only one worker enqueues due reminders per transaction window
     if not pg_try_advisory_xact_lock(hashtextextended('ocg:event-reminder-enqueue', 0)) then
@@ -52,53 +55,74 @@ begin
         order by e.starts_at asc, e.event_id asc
         for update of e skip locked
     loop
-        -- Collect verified attendees and speakers to notify
-        select coalesce(array_agg(recipient.user_id order by recipient.user_id), '{}')
-        into v_recipients
-        from (
-            -- Attendees
-            select ea.user_id
-            from event_attendee ea
-            join "user" u using (user_id)
-            where ea.event_id = v_event.event_id
+        -- Collect verified attendees who should see attendance cancellation copy
+        select coalesce(array_agg(ea.user_id order by ea.user_id), '{}')
+        into v_attendee_recipients
+        from event_attendee ea
+        join "user" u using (user_id)
+        where ea.event_id = v_event.event_id
+        and ea.status = 'confirmed'
+        and u.email_verified = true;
+
+        -- Collect verified speaker-only users who cannot cancel attendance
+        select coalesce(array_agg(es.user_id order by es.user_id), '{}')
+        into v_speaker_only_recipients
+        from event_speaker es
+        join "user" u using (user_id)
+        left join event_attendee ea
+            on ea.event_id = es.event_id
+            and ea.user_id = es.user_id
             and ea.status = 'confirmed'
-            and u.email_verified = true
+        where es.event_id = v_event.event_id
+        and ea.user_id is null
+        and u.email_verified = true;
 
-            union
-
-            -- Speakers
-            select es.user_id
-            from event_speaker es
-            join "user" u using (user_id)
-            where es.event_id = v_event.event_id
-            and u.email_verified = true
-        ) recipient;
+        -- Count recipient groups before building notification data
+        v_recipient_count :=
+            cardinality(v_attendee_recipients) + cardinality(v_speaker_only_recipients);
 
         -- Enqueue reminder notifications when recipients exist
-        if coalesce(array_length(v_recipients, 1), 0) > 0 then
-            perform enqueue_notification(
-                'event-reminder',
-                jsonb_strip_nulls(
-                    jsonb_build_object(
-                        'event',
-                            get_event_summary(
-                                v_event.community_id,
-                                v_event.group_id,
-                                v_event.event_id
-                            )::jsonb,
-                        'link', format(
-                            '%s/%s/group/%s/event/%s',
-                            v_base_url,
-                            v_event.community_name,
-                            coalesce(v_event.group_slug_pretty, v_event.group_slug),
-                            v_event.event_slug
-                        ),
-                        'theme', v_event.theme
-                    )
-                ),
-                '[]'::jsonb,
-                v_recipients
+        if v_recipient_count > 0 then
+            -- Build base template data shared by all reminder recipients
+            v_template_data := jsonb_strip_nulls(
+                jsonb_build_object(
+                    'event',
+                        get_event_summary(
+                            v_event.community_id,
+                            v_event.group_id,
+                            v_event.event_id
+                        )::jsonb,
+                    'link', format(
+                        '%s/%s/group/%s/event/%s',
+                        v_base_url,
+                        v_event.community_name,
+                        coalesce(v_event.group_slug_pretty, v_event.group_slug),
+                        v_event.event_slug
+                    ),
+                    'dashboard_link', format('%s/dashboard/user?tab=events', v_base_url),
+                    'theme', v_event.theme
+                )
             );
+
+            -- Enqueue attendee reminders with attendance cancellation copy enabled
+            if cardinality(v_attendee_recipients) > 0 then
+                perform enqueue_notification(
+                    'event-reminder',
+                    v_template_data || jsonb_build_object('show_attendance_cancellation_copy', true),
+                    '[]'::jsonb,
+                    v_attendee_recipients
+                );
+            end if;
+
+            -- Enqueue speaker-only reminders without attendance cancellation copy
+            if cardinality(v_speaker_only_recipients) > 0 then
+                perform enqueue_notification(
+                    'event-reminder',
+                    v_template_data || jsonb_build_object('show_attendance_cancellation_copy', false),
+                    '[]'::jsonb,
+                    v_speaker_only_recipients
+                );
+            end if;
 
             -- Mark the current start time as evaluated and reminders as sent
             update event set
@@ -106,7 +130,8 @@ begin
                 event_reminder_sent_at = now()
             where event_id = v_event.event_id;
 
-            v_reminders_enqueued := v_reminders_enqueued + array_length(v_recipients, 1);
+            -- Track notifications created for both reminder recipient groups
+            v_reminders_enqueued := v_reminders_enqueued + v_recipient_count;
         else
             -- Mark the current start time as evaluated when there are no recipients
             update event set

--- a/database/migrations/schema/0048_add_event_attendance_canceled_notification.sql
+++ b/database/migrations/schema/0048_add_event_attendance_canceled_notification.sql
@@ -1,0 +1,5 @@
+-- Add notification kind for attendance cancellation confirmations.
+
+insert into notification_kind (name)
+values ('event-attendance-canceled')
+on conflict (name) do nothing;

--- a/database/tests/functions/dashboard-group/cancel_event_attendee_attendance.sql
+++ b/database/tests/functions/dashboard-group/cancel_event_attendee_attendance.sql
@@ -1,0 +1,195 @@
+-- ============================================================================
+-- SETUP
+-- ============================================================================
+
+begin;
+select plan(8);
+
+-- ============================================================================
+-- VARIABLES
+-- ============================================================================
+
+\set actorID '00000000-0000-0000-0000-000000000001'
+\set attendeeID '00000000-0000-0000-0000-000000000002'
+\set categoryID '00000000-0000-0000-0000-000000000003'
+\set communityID '00000000-0000-0000-0000-000000000004'
+\set eventCategoryID '00000000-0000-0000-0000-000000000005'
+\set eventID '00000000-0000-0000-0000-000000000006'
+\set eventPaidID '00000000-0000-0000-0000-000000000007'
+\set eventTicketTypeID '00000000-0000-0000-0000-000000000008'
+\set groupID '00000000-0000-0000-0000-000000000009'
+\set paidAttendeeID '00000000-0000-0000-0000-000000000010'
+\set purchaseID '00000000-0000-0000-0000-000000000011'
+
+-- ============================================================================
+-- SEED DATA
+-- ============================================================================
+
+-- Community
+insert into community (community_id, name, display_name, description, logo_url, banner_mobile_url, banner_url)
+values (:'communityID', 'c1', 'C1', 'd', 'https://e/logo.png', 'https://e/bm.png', 'https://e/b.png');
+
+-- Group category
+insert into group_category (group_category_id, name, community_id)
+values (:'categoryID', 'Tech', :'communityID');
+
+-- Event category
+insert into event_category (event_category_id, name, community_id)
+values (:'eventCategoryID', 'General', :'communityID');
+
+-- Group
+insert into "group" (group_id, community_id, group_category_id, name, slug)
+values (:'groupID', :'communityID', :'categoryID', 'G1', 'g1');
+
+-- Users
+insert into "user" (auth_hash, email, email_verified, name, user_id, username)
+values
+    ('hash-actor', 'actor@example.com', true, 'Actor', :'actorID', 'actor'),
+    ('hash-attendee', 'attendee@example.com', true, 'Attendee', :'attendeeID', 'attendee'),
+    ('hash-paid', 'paid@example.com', true, 'Paid', :'paidAttendeeID', 'paid');
+
+-- Events
+insert into event (
+    event_id,
+    name,
+    slug,
+    description,
+    timezone,
+    event_category_id,
+    event_kind_id,
+    group_id,
+    payment_currency_code,
+    published,
+    starts_at
+)
+values
+    (:'eventID', 'Free Event', 'free-event', 'd', 'UTC', :'eventCategoryID', 'in-person', :'groupID', null, true, now() + interval '7 days'),
+    (:'eventPaidID', 'Paid Event', 'paid-event', 'd', 'UTC', :'eventCategoryID', 'in-person', :'groupID', 'USD', true, now() + interval '7 days');
+
+-- Ticket type and paid purchase
+insert into event_ticket_type (event_ticket_type_id, event_id, "order", seats_total, title)
+values (:'eventTicketTypeID', :'eventPaidID', 1, 10, 'Paid admission');
+
+insert into event_purchase (
+    amount_minor,
+    currency_code,
+    event_id,
+    event_purchase_id,
+    event_ticket_type_id,
+    status,
+    ticket_title,
+    user_id
+)
+values (2500, 'USD', :'eventPaidID', :'purchaseID', :'eventTicketTypeID', 'completed', 'Paid admission', :'paidAttendeeID');
+
+-- Attendees
+insert into event_attendee (event_id, user_id, status)
+values
+    (:'eventID', :'attendeeID', 'confirmed'),
+    (:'eventPaidID', :'paidAttendeeID', 'confirmed');
+
+-- ============================================================================
+-- TESTS
+-- ============================================================================
+
+-- Should cancel confirmed attendance.
+select results_eq(
+    $$ select cancel_event_attendee_attendance(
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000009',
+        '00000000-0000-0000-0000-000000000006',
+        '00000000-0000-0000-0000-000000000002'
+    )::jsonb $$,
+    $$ values ('{"left_status": "attendee", "promoted_user_ids": []}'::jsonb) $$,
+    'Should cancel a confirmed attendance'
+);
+
+select is(
+    (select count(*)::int from event_attendee where event_id = :'eventID' and user_id = :'attendeeID'),
+    0,
+    'Should remove the attendee row'
+);
+
+-- Should create the expected audit row.
+select results_eq(
+    $$
+        select
+            action,
+            actor_user_id,
+            community_id,
+            event_id,
+            group_id,
+            resource_id,
+            resource_type,
+            details
+        from audit_log
+    $$,
+    $$
+        values (
+            'event_attendee_attendance_canceled',
+            '00000000-0000-0000-0000-000000000001'::uuid,
+            '00000000-0000-0000-0000-000000000004'::uuid,
+            '00000000-0000-0000-0000-000000000006'::uuid,
+            '00000000-0000-0000-0000-000000000009'::uuid,
+            '00000000-0000-0000-0000-000000000002'::uuid,
+            'user',
+            '{"event_id": "00000000-0000-0000-0000-000000000006", "user_id": "00000000-0000-0000-0000-000000000002"}'::jsonb
+        )
+    $$,
+    'Should create the expected audit row'
+);
+
+-- Should reject canceling missing confirmed attendees.
+select throws_ok(
+    $$ select cancel_event_attendee_attendance(
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000009',
+        '00000000-0000-0000-0000-000000000006',
+        '00000000-0000-0000-0000-000000000002'
+    ) $$,
+    'confirmed event attendee not found',
+    'Should reject canceling missing confirmed attendance'
+);
+
+-- Should reject events outside the selected group.
+select throws_ok(
+    $$ select cancel_event_attendee_attendance(
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-999999999999',
+        '00000000-0000-0000-0000-000000000006',
+        '00000000-0000-0000-0000-000000000002'
+    ) $$,
+    'event not found or inactive',
+    'Should reject events outside the selected group'
+);
+
+-- Should reject paid attendees.
+select throws_ok(
+    $$ select cancel_event_attendee_attendance(
+        '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-000000000009',
+        '00000000-0000-0000-0000-000000000007',
+        '00000000-0000-0000-0000-000000000010'
+    ) $$,
+    'paid attendees cannot be canceled from attendee actions',
+    'Should reject paid attendee cancellation'
+);
+
+select is(
+    (select count(*)::int from event_attendee where event_id = :'eventPaidID' and user_id = :'paidAttendeeID'),
+    1,
+    'Should keep paid attendee rows'
+);
+
+select is(
+    (select status from event_purchase where event_purchase_id = :'purchaseID'),
+    'completed',
+    'Should keep paid purchases unchanged'
+);
+
+-- ============================================================================
+-- CLEANUP
+-- ============================================================================
+
+select * from finish();
+rollback;

--- a/database/tests/functions/dashboard-group/list_group_audit_logs.sql
+++ b/database/tests/functions/dashboard-group/list_group_audit_logs.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(4);
+select plan(5);
 
 -- ============================================================================
 -- VARIABLES
@@ -21,6 +21,7 @@ select plan(4);
 \set audit8ID '00000000-0000-0000-0000-000000000109'
 \set audit9ID '00000000-0000-0000-0000-000000000110'
 \set audit10ID '00000000-0000-0000-0000-000000000111'
+\set audit11ID '00000000-0000-0000-0000-000000000112'
 \set communityID '00000000-0000-0000-0000-000000000001'
 \set groupCategoryID '00000000-0000-0000-0000-000000000021'
 \set groupID '00000000-0000-0000-0000-000000000031'
@@ -180,6 +181,18 @@ insert into audit_log (
         'user'
     ),
     (
+        :'audit11ID',
+        'event_attendee_attendance_canceled',
+        :'actor1ID',
+        'alice',
+        :'communityID',
+        '2024-03-02 16:30:00+00',
+        '{"event_id": "00000000-0000-0000-0000-000000000057"}',
+        :'groupID',
+        :'targetUserID',
+        'user'
+    ),
+    (
         :'audit3ID',
         'event_added',
         :'actor1ID',
@@ -238,6 +251,16 @@ select is(
                 "resource_id": "00000000-0000-0000-0000-000000000031",
                 "resource_name": "Platform",
                 "resource_type": "group"
+            },
+            {
+                "action": "event_attendee_attendance_canceled",
+                "actor_username": "alice",
+                "audit_log_id": "00000000-0000-0000-0000-000000000112",
+                "created_at": 1709397000,
+                "details": {"event_id": "00000000-0000-0000-0000-000000000057"},
+                "resource_id": "00000000-0000-0000-0000-000000000041",
+                "resource_name": "Sara",
+                "resource_type": "user"
             },
             {
                 "action": "event_attendee_invitation_canceled",
@@ -321,7 +344,7 @@ select is(
             }
         ]'::jsonb,
         'total',
-        9
+        10
     ),
     'Should return only group dashboard actions for the selected group'
 );
@@ -352,6 +375,32 @@ select is(
     'Should filter group audit logs by actor and action'
 );
 
+-- Should filter group audit logs by attendee attendance cancellation action
+select is(
+    list_group_audit_logs(
+        :'groupID'::uuid,
+        '{"action": "event_attendee_attendance_canceled", "limit": 50, "offset": 0, "sort": "created-desc"}'::jsonb
+    )::jsonb,
+    jsonb_build_object(
+        'logs',
+        '[
+            {
+                "action": "event_attendee_attendance_canceled",
+                "actor_username": "alice",
+                "audit_log_id": "00000000-0000-0000-0000-000000000112",
+                "created_at": 1709397000,
+                "details": {"event_id": "00000000-0000-0000-0000-000000000057"},
+                "resource_id": "00000000-0000-0000-0000-000000000041",
+                "resource_name": "Sara",
+                "resource_type": "user"
+            }
+        ]'::jsonb,
+        'total',
+        1
+    ),
+    'Should filter group audit logs by attendee attendance cancellation action'
+);
+
 -- Should return group audit logs in ascending order with pagination
 select is(
     list_group_audit_logs(
@@ -373,7 +422,7 @@ select is(
             }
         ]'::jsonb,
         'total',
-        8
+        9
     ),
     'Should return group audit logs in ascending order with pagination'
 );

--- a/database/tests/functions/dashboard-user/list_user_events.sql
+++ b/database/tests/functions/dashboard-user/list_user_events.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(4);
+select plan(5);
 
 -- ============================================================================
 -- VARIABLES
@@ -17,6 +17,7 @@ select plan(4);
 \set groupInactiveID '00000000-0000-0000-0000-000000000033'
 \set userEmptyID '00000000-0000-0000-0000-000000000099'
 \set userID '00000000-0000-0000-0000-000000000081'
+\set userPaidID '00000000-0000-0000-0000-000000000082'
 
 \set eventAID '00000000-0000-0000-0000-000000000101'
 \set eventBID '00000000-0000-0000-0000-000000000102'
@@ -27,6 +28,10 @@ select plan(4);
 \set eventNoStartsAtID '00000000-0000-0000-0000-000000000107'
 \set eventPastID '00000000-0000-0000-0000-000000000108'
 \set eventPendingInvitationID '00000000-0000-0000-0000-000000000111'
+\set eventPaidID '00000000-0000-0000-0000-000000000112'
+\set eventPaidPriceWindowID '00000000-0000-0000-0000-000000000115'
+\set eventPaidPurchaseID '00000000-0000-0000-0000-000000000113'
+\set eventPaidTicketTypeID '00000000-0000-0000-0000-000000000114'
 \set eventUnpublishedID '00000000-0000-0000-0000-000000000109'
 \set eventDeletedGroupID '00000000-0000-0000-0000-000000000110'
 
@@ -65,7 +70,8 @@ insert into "group" (group_id, active, community_id, deleted, group_category_id,
 
 -- User
 insert into "user" (user_id, auth_hash, email, email_verified, username, name) values
-    (:'userID', 'auth-hash', 'alice@example.com', true, 'alice', 'Alice');
+    (:'userID', 'auth-hash', 'alice@example.com', true, 'alice', 'Alice'),
+    (:'userPaidID', 'paid-auth-hash', 'paid@example.com', true, 'paid', 'Paid User');
 
 -- Events
 insert into event (
@@ -235,12 +241,55 @@ insert into event (
         'event-deleted-group',
         '2099-01-17 10:00:00+00',
         'UTC'
+    ),
+    (
+        :'eventPaidID',
+        false,
+        false,
+        'Event Paid',
+        :'eventCategoryID',
+        'in-person',
+        :'groupID',
+        'Event Paid',
+        true,
+        'event-paid',
+        '2099-01-18 10:00:00+00',
+        'UTC'
     );
+
+update event
+set payment_currency_code = 'USD'
+where event_id = :'eventPaidID'::uuid;
 
 -- Sessions for speaker role tests
 insert into session (session_id, event_id, name, session_kind_id, starts_at) values
     (:'sessionAID', :'eventAID', 'Session A', 'virtual', '2099-01-10 11:00:00+00'),
     (:'sessionCID', :'eventCID', 'Session C', 'virtual', '2099-01-12 11:00:00+00');
+
+-- Event ticket types
+insert into event_ticket_type (
+    event_ticket_type_id,
+    event_id,
+    "order",
+    seats_total,
+    title
+) values (
+    :'eventPaidTicketTypeID',
+    :'eventPaidID',
+    1,
+    1,
+    'Paid admission'
+);
+
+insert into event_ticket_price_window (
+    event_ticket_price_window_id,
+    amount_minor,
+    event_ticket_type_id
+) values (
+    :'eventPaidPriceWindowID',
+    1500,
+    :'eventPaidTicketTypeID'
+);
 
 -- User participation
 insert into event_attendee (event_id, user_id, status) values
@@ -252,6 +301,7 @@ insert into event_attendee (event_id, user_id, status) values
     (:'eventInactiveGroupID', :'userID', 'confirmed'),
     (:'eventNoStartsAtID', :'userID', 'confirmed'),
     (:'eventPastID', :'userID', 'confirmed'),
+    (:'eventPaidID', :'userPaidID', 'confirmed'),
     (:'eventPendingInvitationID', :'userID', 'invitation-pending'),
     (:'eventUnpublishedID', :'userID', 'confirmed');
 
@@ -265,6 +315,26 @@ insert into session_speaker (session_id, user_id, featured) values
     (:'sessionAID', :'userID', false),
     (:'sessionCID', :'userID', true);
 
+insert into event_purchase (
+    event_purchase_id,
+    amount_minor,
+    currency_code,
+    event_id,
+    event_ticket_type_id,
+    status,
+    ticket_title,
+    user_id
+) values (
+    :'eventPaidPurchaseID',
+    1500,
+    'USD',
+    :'eventPaidID',
+    :'eventPaidTicketTypeID',
+    'completed',
+    'Paid admission',
+    :'userPaidID'
+);
+
 -- ============================================================================
 -- TESTS
 -- ============================================================================
@@ -276,18 +346,24 @@ select is(
         'events',
         jsonb_build_array(
             jsonb_build_object(
+                'can_cancel_attendance',
+                false,
                 'event',
                 get_event_summary(:'communityID'::uuid, :'groupID'::uuid, :'eventAID'::uuid)::jsonb,
                 'roles',
                 jsonb_build_array('Attendee', 'Host', 'Speaker')
             ),
             jsonb_build_object(
+                'can_cancel_attendance',
+                true,
                 'event',
                 get_event_summary(:'communityID'::uuid, :'groupID'::uuid, :'eventBID'::uuid)::jsonb,
                 'roles',
                 jsonb_build_array('Attendee')
             ),
             jsonb_build_object(
+                'can_cancel_attendance',
+                false,
                 'event',
                 get_event_summary(:'communityID'::uuid, :'groupID'::uuid, :'eventCID'::uuid)::jsonb,
                 'roles',
@@ -319,6 +395,8 @@ select is(
         'events',
         jsonb_build_array(
             jsonb_build_object(
+                'can_cancel_attendance',
+                true,
                 'event',
                 get_event_summary(:'communityID'::uuid, :'groupID'::uuid, :'eventBID'::uuid)::jsonb,
                 'roles',
@@ -329,6 +407,27 @@ select is(
         3
     ),
     'Should paginate events and keep total count'
+);
+
+-- Should not allow paid attendee-only events to be canceled from My Events
+select is(
+    list_user_events(:'userPaidID'::uuid, '{"limit": 10, "offset": 0}'::jsonb)::jsonb,
+    jsonb_build_object(
+        'events',
+        jsonb_build_array(
+            jsonb_build_object(
+                'can_cancel_attendance',
+                false,
+                'event',
+                get_event_summary(:'communityID'::uuid, :'groupID'::uuid, :'eventPaidID'::uuid)::jsonb,
+                'roles',
+                jsonb_build_array('Attendee')
+            )
+        ),
+        'total',
+        1
+    ),
+    'Should not allow paid attendee-only events to be canceled from My Events'
 );
 
 -- Should return empty result for users without events

--- a/database/tests/functions/notifications/enqueue_due_event_reminders.sql
+++ b/database/tests/functions/notifications/enqueue_due_event_reminders.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(14);
+select plan(17);
 
 -- ============================================================================
 -- VARIABLES
@@ -444,6 +444,45 @@ select is(
     ),
     'https://example.test/test-community/group/test-group-pretty/event/due-event',
     'Should build reminder link using the provided base URL'
+);
+
+-- Should build dashboard link using the provided base URL
+select is(
+    (
+        select ntd.data->>'dashboard_link'
+        from notification n
+        join notification_template_data ntd using (notification_template_data_id)
+        where n.kind = 'event-reminder'
+        limit 1
+    ),
+    'https://example.test/dashboard/user?tab=events',
+    'Should build dashboard link using the provided base URL'
+);
+
+-- Should show attendance cancellation copy for attendee recipients
+select is(
+    (
+        select ntd.data->>'show_attendance_cancellation_copy'
+        from notification n
+        join notification_template_data ntd using (notification_template_data_id)
+        where n.kind = 'event-reminder'
+        and n.user_id = :'userVerifiedAttendeeID'::uuid
+    ),
+    'true',
+    'Should show attendance cancellation copy for attendee recipients'
+);
+
+-- Should prevent speaker-only recipients from seeing cancellation reminder copy
+select is(
+    (
+        select ntd.data->>'show_attendance_cancellation_copy'
+        from notification n
+        join notification_template_data ntd using (notification_template_data_id)
+        where n.kind = 'event-reminder'
+        and n.user_id = :'userVerifiedSpeakerID'::uuid
+    ),
+    'false',
+    'Should prevent speaker-only recipients from seeing cancellation reminder copy'
 );
 
 -- Should include waitlist fields in reminder template data

--- a/database/tests/schema/05_functions_and_triggers.sql
+++ b/database/tests/schema/05_functions_and_triggers.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(242);
+select plan(243);
 
 -- ============================================================================
 -- TESTS
@@ -37,6 +37,7 @@ select has_function('attach_checkout_session_to_event_purchase');
 select has_function('attend_event');
 select has_function('begin_event_refund_approval');
 select has_function('cancel_event');
+select has_function('cancel_event_attendee_attendance');
 select has_function('cancel_event_checkout');
 select has_function('cancel_event_series_events');
 select has_function('cancel_event_attendee_invitation');

--- a/database/tests/schema/06_constraints_and_reference_data.sql
+++ b/database/tests/schema/06_constraints_and_reference_data.sql
@@ -253,6 +253,7 @@ select results_eq(
         ('cfs-submission-updated', false),
         ('community-team-invitation', false),
         ('email-verification', false),
+        ('event-attendance-canceled', false),
         ('event-canceled', false),
         ('event-custom', true),
         ('event-invitation', false),

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -32,7 +32,10 @@ use crate::{
         },
     },
     types::{
-        event::{EventCategory, EventKindSummary as EventKind, SessionKindSummary as SessionKind},
+        event::{
+            EventCategory, EventKindSummary as EventKind, EventLeaveOutcome,
+            SessionKindSummary as SessionKind,
+        },
         group::{GroupRole, GroupRoleSummary, GroupSponsor},
         payments::{GroupPaymentRecipient, PaymentProvider},
     },
@@ -84,6 +87,15 @@ pub(crate) trait DBDashboardGroup {
 
     /// Cancels an event (sets canceled=true).
     async fn cancel_event(&self, actor_user_id: Uuid, group_id: Uuid, event_id: Uuid) -> Result<()>;
+
+    /// Cancels a confirmed event attendee from the group dashboard.
+    async fn cancel_event_attendee_attendance(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        event_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<EventLeaveOutcome>;
 
     /// Cancels a pending organizer-created event invitation.
     async fn cancel_event_attendee_invitation(
@@ -462,6 +474,22 @@ impl DBDashboardGroup for PgDB {
         self.execute(
             "select cancel_event($1::uuid, $2::uuid, $3::uuid)",
             &[&actor_user_id, &group_id, &event_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::cancel_event_attendee_attendance`]
+    #[instrument(skip(self), err)]
+    async fn cancel_event_attendee_attendance(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        event_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<EventLeaveOutcome> {
+        self.fetch_json_one(
+            "select cancel_event_attendee_attendance($1::uuid, $2::uuid, $3::uuid, $4::uuid)",
+            &[&actor_user_id, &group_id, &event_id, &user_id],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -335,6 +335,13 @@ mock! {
             role: &crate::types::group::GroupRole,
         ) -> Result<()>;
         async fn cancel_event(&self, actor_user_id: Uuid, group_id: Uuid, event_id: Uuid) -> Result<()>;
+        async fn cancel_event_attendee_attendance(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            event_id: Uuid,
+            user_id: Uuid,
+        ) -> Result<crate::types::event::EventLeaveOutcome>;
         async fn cancel_event_attendee_invitation(
             &self,
             actor_user_id: Uuid,

--- a/ocg-server/src/handlers.rs
+++ b/ocg-server/src/handlers.rs
@@ -28,6 +28,8 @@ pub(crate) mod group;
 pub(crate) mod images;
 /// Meetings handlers.
 pub(crate) mod meetings;
+/// Handler-layer notification helpers.
+pub(crate) mod notifications;
 /// Payments handlers.
 pub(crate) mod payments;
 /// Global site handlers.

--- a/ocg-server/src/handlers/dashboard/group/attendees.rs
+++ b/ocg-server/src/handlers/dashboard/group/attendees.rs
@@ -22,6 +22,7 @@ use crate::{
     handlers::{
         error::HandlerError,
         extractors::{CurrentUser, SelectedCommunityId, SelectedGroupId, ValidatedForm},
+        notifications::enqueue_attendance_canceled_notification,
     },
     router::serde_qs_config,
     services::{
@@ -30,10 +31,10 @@ use crate::{
     },
     templates::{
         dashboard::group::attendees::{self, AttendeesFilters, AttendeesPaginationFilters},
-        notifications::{EventCustom, EventInvitation, EventWelcome},
+        notifications::{EventCustom, EventInvitation, EventWaitlistPromoted, EventWelcome},
     },
     types::{pagination::NavigationLinks, permissions::GroupPermission},
-    util::{build_event_calendar_attachment, build_event_page_link},
+    util::{build_event_calendar_attachment, build_event_page_link, build_user_dashboard_events_link},
     validation::{
         MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_M, MAX_LEN_NOTIFICATION_BODY, trimmed_non_empty,
         trimmed_non_empty_opt,
@@ -142,6 +143,8 @@ pub(crate) async fn accept_invitation_request(
         event,
         link,
         theme: site_settings.theme,
+
+        dashboard_link: Some(build_user_dashboard_events_link(base_url)),
     };
     let notification = NewNotification {
         attachments: vec![calendar_ics],
@@ -185,6 +188,79 @@ pub(crate) async fn approve_refund_request(
             review_note: review.review_note.clone(),
         })
         .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-event-attendees")],
+    )
+        .into_response())
+}
+
+/// Cancels a confirmed attendee's event attendance.
+#[instrument(skip_all, err)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn cancel_event_attendee_attendance(
+    CurrentUser(user): CurrentUser,
+    SelectedCommunityId(community_id): SelectedCommunityId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((event_id, user_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, HandlerError> {
+    // Cancel the attendee and collect any waitlist promotions
+    let cancel_result = db
+        .cancel_event_attendee_attendance(user.user_id, group_id, event_id, user_id)
+        .await?;
+
+    // Load notification context after cancellation succeeds
+    let (site_settings, event) = match tokio::try_join!(
+        db.get_site_settings(),
+        db.get_event_summary_by_id(community_id, event_id)
+    ) {
+        Ok(context) => context,
+        Err(err) => {
+            warn!(error = %err, "failed to load event attendance cancellation notification context");
+            return Ok((
+                StatusCode::NO_CONTENT,
+                [("HX-Trigger", "refresh-event-attendees")],
+            )
+                .into_response());
+        }
+    };
+
+    // Confirm the canceled attendance to the attendee
+    if let Err(err) = enqueue_attendance_canceled_notification(
+        &event,
+        &notifications_manager,
+        user_id,
+        &server_cfg,
+        &site_settings,
+    )
+    .await
+    {
+        warn!(error = %err, "failed to enqueue event attendance cancellation notification");
+    }
+
+    // Notify users promoted off the waitlist after a spot opens up
+    if !cancel_result.promoted_user_ids.is_empty() && !event.test_event {
+        let base_url = server_cfg.base_url.strip_suffix('/').unwrap_or(&server_cfg.base_url);
+        let calendar_ics = build_event_calendar_attachment(base_url, &event);
+        let template_data = EventWaitlistPromoted {
+            event: event.clone(),
+            link: build_event_page_link(base_url, &event),
+            theme: site_settings.theme,
+        };
+        let notification = NewNotification {
+            attachments: vec![calendar_ics],
+            kind: NotificationKind::EventWaitlistPromoted,
+            recipients: cancel_result.promoted_user_ids,
+            template_data: Some(serde_json::to_value(&template_data)?),
+        };
+        if let Err(err) = notifications_manager.enqueue(&notification).await {
+            warn!(error = %err, "failed to enqueue waitlist promotion notification");
+        }
+    }
 
     Ok((
         StatusCode::NO_CONTENT,

--- a/ocg-server/src/handlers/dashboard/user/events.rs
+++ b/ocg-server/src/handlers/dashboard/user/events.rs
@@ -2,19 +2,28 @@
 
 use askama::Template;
 use axum::{
-    extract::{RawQuery, State},
-    http::HeaderName,
+    extract::{Path, RawQuery, State},
+    http::{HeaderName, StatusCode},
     response::{Html, IntoResponse},
 };
-use tracing::instrument;
+use serde_json::to_value;
+use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::{
+    config::HttpServerConfig,
     db::DynDB,
-    handlers::{error::HandlerError, extractors::CurrentUser},
+    handlers::{
+        error::HandlerError, extractors::CurrentUser, notifications::enqueue_attendance_canceled_notification,
+    },
     router::serde_qs_config,
-    templates::dashboard::user::events,
-    types::pagination::{self, NavigationLinks},
+    services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
+    templates::{dashboard::user::events, notifications::EventWaitlistPromoted},
+    types::{
+        event::EventAttendanceStatus,
+        pagination::{self, NavigationLinks},
+    },
+    util::{build_event_calendar_attachment, build_event_page_link},
 };
 
 #[cfg(test)]
@@ -42,6 +51,85 @@ pub(crate) async fn list_page(
     let headers = [(HeaderName::from_static("hx-push-url"), url)];
 
     Ok((headers, Html(template.render()?)))
+}
+
+// Actions handlers.
+
+/// Cancels the current user's event attendance from the dashboard.
+#[instrument(skip_all, err)]
+pub(crate) async fn cancel_attendance(
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((community_name, event_id)): Path<(String, Uuid)>,
+) -> Result<impl IntoResponse, HandlerError> {
+    // Resolve the community from the dashboard route
+    let community_id = db
+        .get_community_id_by_name(&community_name)
+        .await?
+        .ok_or(HandlerError::NotFound)?;
+
+    // Validate the row still represents active attendee attendance
+    let attendance = db.get_event_attendance(community_id, event_id, user.user_id).await?;
+    if attendance.status != EventAttendanceStatus::Attendee {
+        return Err(anyhow::anyhow!("only attendee attendance can be canceled from My Events").into());
+    }
+
+    // Cancel the user's attendance and collect any waitlist promotions
+    let leave_result = db.leave_event(community_id, event_id, user.user_id).await?;
+
+    // Load notification context after cancellation succeeds
+    let (site_settings, event) = match tokio::try_join!(
+        db.get_site_settings(),
+        db.get_event_summary_by_id(community_id, event_id)
+    ) {
+        Ok(context) => context,
+        Err(err) => {
+            warn!(error = %err, "failed to load user dashboard attendance cancellation notification context");
+            return Ok((
+                StatusCode::NO_CONTENT,
+                [("HX-Trigger", "refresh-user-dashboard-content")],
+            ));
+        }
+    };
+
+    // Confirm the canceled attendance to the user
+    if let Err(err) = enqueue_attendance_canceled_notification(
+        &event,
+        &notifications_manager,
+        user.user_id,
+        &server_cfg,
+        &site_settings,
+    )
+    .await
+    {
+        warn!(error = %err, "failed to enqueue event attendance cancellation notification");
+    }
+
+    // Notify users promoted off the waitlist after a spot opens up
+    if !leave_result.promoted_user_ids.is_empty() && !event.test_event {
+        let base_url = server_cfg.base_url.strip_suffix('/').unwrap_or(&server_cfg.base_url);
+        let template_data = EventWaitlistPromoted {
+            event: event.clone(),
+            link: build_event_page_link(base_url, &event),
+            theme: site_settings.theme,
+        };
+        let notification = NewNotification {
+            attachments: vec![build_event_calendar_attachment(base_url, &event)],
+            kind: NotificationKind::EventWaitlistPromoted,
+            recipients: leave_result.promoted_user_ids,
+            template_data: Some(to_value(&template_data)?),
+        };
+        if let Err(err) = notifications_manager.enqueue(&notification).await {
+            warn!(error = %err, "failed to enqueue waitlist promotion notification");
+        }
+    }
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-user-dashboard-content")],
+    ))
 }
 
 // Helpers.

--- a/ocg-server/src/handlers/dashboard/user/events/tests.rs
+++ b/ocg-server/src/handlers/dashboard/user/events/tests.rs
@@ -7,12 +7,17 @@ use axum::{
     },
 };
 use axum_login::tower_sessions::session;
+use serde_json::from_value;
 use tower::ServiceExt;
 use uuid::Uuid;
 
 use crate::{
-    db::mock::MockDB, handlers::tests::*, services::notifications::MockNotificationsManager,
+    db::mock::MockDB,
+    handlers::tests::*,
+    services::notifications::{MockNotificationsManager, NotificationKind},
     templates::dashboard::DASHBOARD_PAGINATION_LIMIT,
+    templates::notifications::{EventAttendanceCanceled, EventWaitlistPromoted},
+    types::event::{EventAttendanceInfo, EventAttendanceStatus, EventLeaveOutcome},
 };
 
 #[tokio::test]
@@ -26,6 +31,7 @@ async fn test_list_page_success() {
     let group_id = Uuid::new_v4();
     let output = crate::templates::dashboard::user::events::UserEventsOutput {
         events: vec![crate::templates::dashboard::user::events::UserEvent {
+            can_cancel_attendance: false,
             event: sample_event_summary(event_id, group_id),
             roles: vec!["Attendee".to_string(), "Host".to_string()],
         }],
@@ -166,5 +172,119 @@ async fn test_list_page_db_error() {
 
     // Check response matches expectations.
     assert_eq!(parts.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test]
+async fn test_cancel_attendance_promotes_waitlisted_users_and_enqueues_notification() {
+    // Setup identifiers and data structures.
+    let community_id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let promoted_user_id = Uuid::new_v4();
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let auth_hash = "hash".to_string();
+    let session_record = sample_session_record(session_id, user_id, &auth_hash, None, None);
+    let event = sample_event_summary(event_id, group_id);
+    let site_settings = sample_site_settings();
+    let site_settings_for_notification = site_settings.clone();
+
+    // Setup database mock.
+    let mut db = MockDB::new();
+    db.expect_get_session()
+        .times(1)
+        .withf(move |id| *id == session_id)
+        .returning(move |_| Ok(Some(session_record.clone())));
+    db.expect_get_user_by_id()
+        .times(1)
+        .withf(move |id| *id == user_id)
+        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
+    db.expect_get_community_id_by_name()
+        .times(1)
+        .withf(|name| name == "test-community")
+        .returning(move |_| Ok(Some(community_id)));
+    db.expect_get_event_attendance()
+        .times(1)
+        .withf(move |cid, eid, uid| *cid == community_id && *eid == event_id && *uid == user_id)
+        .returning(|_, _, _| {
+            Ok(EventAttendanceInfo {
+                is_checked_in: false,
+                status: EventAttendanceStatus::Attendee,
+
+                purchase_amount_minor: None,
+                refund_request_status: None,
+                resume_checkout_url: None,
+            })
+        });
+    db.expect_leave_event()
+        .times(1)
+        .withf(move |cid, eid, uid| *cid == community_id && *eid == event_id && *uid == user_id)
+        .returning(move |_, _, _| {
+            Ok(EventLeaveOutcome {
+                left_status: EventAttendanceStatus::Attendee,
+                promoted_user_ids: vec![promoted_user_id],
+            })
+        });
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(move || Ok(site_settings.clone()));
+    db.expect_get_event_summary_by_id()
+        .times(1)
+        .withf(move |cid, eid| *cid == community_id && *eid == event_id)
+        .returning(move |_, _| Ok(event.clone()));
+
+    // Setup notifications manager mock.
+    let mut nm = MockNotificationsManager::new();
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::EventAttendanceCanceled)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref().is_some_and(|value| {
+                    from_value::<EventAttendanceCanceled>(value.clone()).is_ok_and(|template| {
+                        template.dashboard_link == "/dashboard/user?tab=events"
+                            && template.link == "/test-community/group/def5678/event/ghi9abc"
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::EventWaitlistPromoted)
+                && notification.recipients == vec![promoted_user_id]
+                && notification.attachments.len() == 1
+                && notification.attachments[0].file_name == "event-ghi9abc.ics"
+                && notification.template_data.as_ref().is_some_and(|value| {
+                    from_value::<EventWaitlistPromoted>(value.clone()).is_ok_and(|template| {
+                        template.link == "/test-community/group/def5678/event/ghi9abc"
+                            && template.theme.primary_color
+                                == site_settings_for_notification.theme.primary_color
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
+
+    // Setup router and send request.
+    let router = TestRouterBuilder::new(db, nm).build().await;
+    let request = Request::builder()
+        .method("DELETE")
+        .uri(format!(
+            "/dashboard/user/events/test-community/{event_id}/attendance"
+        ))
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+
+    // Check response matches expectations.
+    assert_eq!(parts.status, StatusCode::NO_CONTENT);
+    assert_eq!(
+        parts.headers.get("HX-Trigger"),
+        Some(&HeaderValue::from_static("refresh-user-dashboard-content"))
+    );
     assert!(bytes.is_empty());
 }

--- a/ocg-server/src/handlers/dashboard/user/invitations.rs
+++ b/ocg-server/src/handlers/dashboard/user/invitations.rs
@@ -22,7 +22,7 @@ use crate::{
     services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
     templates::dashboard::user::invitations,
     templates::notifications::EventWelcome,
-    util::{build_event_calendar_attachment, build_event_page_link},
+    util::{build_event_calendar_attachment, build_event_page_link, build_user_dashboard_events_link},
 };
 
 #[cfg(test)]
@@ -92,10 +92,13 @@ pub(crate) async fn accept_event_attendee_invitation(
         }
     };
     let base_url = server_cfg.base_url.strip_suffix('/').unwrap_or(&server_cfg.base_url);
+    let link = build_event_page_link(base_url, &event);
     let template_data = EventWelcome {
-        link: build_event_page_link(base_url, &event),
         event,
+        link,
         theme: site_settings.theme,
+
+        dashboard_link: Some(build_user_dashboard_events_link(base_url)),
     };
     let notification = NewNotification {
         attachments: vec![build_event_calendar_attachment(base_url, &template_data.event)],

--- a/ocg-server/src/handlers/event.rs
+++ b/ocg-server/src/handlers/event.rs
@@ -20,6 +20,7 @@ use crate::{
     db::{DynDB, payments::PrepareEventCheckoutPurchaseInput},
     handlers::{
         extractors::{CurrentUser, ValidatedForm, ValidatedFormQs},
+        notifications::try_enqueue_attendance_canceled_notification,
         request_matches_site,
         site::not_found,
         trim_public_gallery_images,
@@ -39,7 +40,7 @@ use crate::{
         event::{EventAttendanceStatus, EventFull, EventSummary},
         payments::{EventPurchaseStatus, EventTicketType, PreparedEventCheckout},
     },
-    util::{build_event_calendar_attachment, build_event_page_link},
+    util::{build_event_calendar_attachment, build_event_page_link, build_user_dashboard_events_link},
     validation::{
         MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_EVENT_LABELS_PER_SUBMISSION, MAX_LEN_S, trimmed_non_empty_opt,
     },
@@ -267,9 +268,11 @@ pub(crate) async fn attend_event(
             // Confirm the RSVP with the event details and calendar attachment
             let calendar_ics = build_event_calendar_attachment(base_url, &event);
             let template_data = EventWelcome {
-                link: link.clone(),
                 event: event.clone(),
+                link: link.clone(),
                 theme: site_settings.theme.clone(),
+
+                dashboard_link: Some(build_user_dashboard_events_link(base_url)),
             };
             let notification = NewNotification {
                 attachments: vec![calendar_ics],
@@ -411,22 +414,36 @@ pub(crate) async fn leave_event(
     let base_url = server_cfg.base_url.strip_suffix('/').unwrap_or(&server_cfg.base_url);
     let link = build_event_page_link(base_url, &event);
 
-    // Only send a leave notification when the user exits the waitlist
-    if leave_result.left_status == EventAttendanceStatus::Waitlisted {
-        let template_data = EventWaitlistLeft {
-            event: event.clone(),
-            link: link.clone(),
-            theme: site_settings.theme.clone(),
-        };
-        let notification = NewNotification {
-            attachments: vec![],
-            kind: NotificationKind::EventWaitlistLeft,
-            recipients: vec![user.user_id],
-            template_data: Some(to_value(&template_data)?),
-        };
-        if let Err(err) = notifications_manager.enqueue(&notification).await {
-            warn!(error = %err, "failed to enqueue event waitlist leave notification");
+    // Confirm attendee cancellation and waitlist exits
+    match leave_result.left_status {
+        EventAttendanceStatus::Attendee => {
+            try_enqueue_attendance_canceled_notification(
+                &event,
+                &notifications_manager,
+                user.user_id,
+                &server_cfg,
+                &site_settings,
+            )
+            .await;
         }
+        EventAttendanceStatus::Waitlisted => {
+            let template_data = EventWaitlistLeft {
+                event: event.clone(),
+                link: link.clone(),
+                theme: site_settings.theme.clone(),
+            };
+            let notification = NewNotification {
+                attachments: vec![],
+                kind: NotificationKind::EventWaitlistLeft,
+                recipients: vec![user.user_id],
+                template_data: Some(to_value(&template_data)?),
+            };
+            if let Err(err) = notifications_manager.enqueue(&notification).await {
+                warn!(error = %err, "failed to enqueue event waitlist leave notification");
+            }
+        }
+        EventAttendanceStatus::PendingApproval => {}
+        _ => unreachable!("leave_event cannot return this left status"),
     }
 
     // Notify users promoted off the waitlist after a spot opens up

--- a/ocg-server/src/handlers/event/tests.rs
+++ b/ocg-server/src/handlers/event/tests.rs
@@ -20,7 +20,9 @@ use crate::{
         notifications::{MockNotificationsManager, NotificationKind},
         payments::MockPaymentsManager,
     },
-    templates::notifications::{EventWaitlistJoined, EventWaitlistLeft, EventWaitlistPromoted, EventWelcome},
+    templates::notifications::{
+        EventAttendanceCanceled, EventWaitlistJoined, EventWaitlistLeft, EventWaitlistPromoted, EventWelcome,
+    },
     types::{
         event::{EventAttendanceInfo, EventAttendanceStatus, EventLeaveOutcome},
         payments::{EventPurchaseStatus, EventTicketCurrentPrice, EventTicketType, PreparedEventCheckout},
@@ -1158,7 +1160,20 @@ async fn test_leave_event_success() {
         .returning(|| Ok(sample_site_settings()));
 
     // Setup notifications manager mock
-    let nm = MockNotificationsManager::new();
+    let mut nm = MockNotificationsManager::new();
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::EventAttendanceCanceled)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref().is_some_and(|value| {
+                    from_value::<EventAttendanceCanceled>(value.clone()).is_ok_and(|template| {
+                        template.dashboard_link == "/dashboard/user?tab=events"
+                            && template.link == "/test-community/group/def5678/event/ghi9abc"
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
 
     // Setup router and send request
     let router = TestRouterBuilder::new(db, nm).build().await;
@@ -1301,6 +1316,19 @@ async fn test_leave_event_promotes_waitlisted_users_and_enqueues_notification() 
 
     // Setup notifications manager mock
     let mut nm = MockNotificationsManager::new();
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::EventAttendanceCanceled)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref().is_some_and(|value| {
+                    from_value::<EventAttendanceCanceled>(value.clone()).is_ok_and(|template| {
+                        template.dashboard_link == "/dashboard/user?tab=events"
+                            && template.link == "/test-community/group/def5678/event/ghi9abc"
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
     nm.expect_enqueue()
         .times(1)
         .withf(move |notification| {

--- a/ocg-server/src/handlers/notifications.rs
+++ b/ocg-server/src/handlers/notifications.rs
@@ -1,0 +1,167 @@
+//! Handler-layer notification helpers.
+
+use anyhow::Result;
+use serde_json::to_value;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::{
+    config::HttpServerConfig,
+    services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
+    templates::notifications::EventAttendanceCanceled,
+    types::{event::EventSummary, site::SiteSettings},
+    util::{build_event_page_link, build_user_dashboard_events_link},
+};
+
+/// Enqueues a generic attendance cancellation confirmation notification.
+pub(crate) async fn enqueue_attendance_canceled_notification(
+    event: &EventSummary,
+    notifications_manager: &DynNotificationsManager,
+    recipient_user_id: Uuid,
+    server_cfg: &HttpServerConfig,
+    site_settings: &SiteSettings,
+) -> Result<()> {
+    // Link preparation
+    let base_url = server_cfg.base_url.strip_suffix('/').unwrap_or(&server_cfg.base_url);
+
+    // Template data
+    let template_data = EventAttendanceCanceled {
+        dashboard_link: build_user_dashboard_events_link(base_url),
+        event: event.clone(),
+        link: build_event_page_link(base_url, event),
+        theme: site_settings.theme.clone(),
+    };
+
+    // Notification enqueue
+    let notification = NewNotification {
+        attachments: vec![],
+        kind: NotificationKind::EventAttendanceCanceled,
+        recipients: vec![recipient_user_id],
+        template_data: Some(to_value(&template_data)?),
+    };
+
+    notifications_manager.enqueue(&notification).await
+}
+
+/// Attempts to send an attendance cancellation confirmation without failing the caller.
+pub(crate) async fn try_enqueue_attendance_canceled_notification(
+    event: &EventSummary,
+    notifications_manager: &DynNotificationsManager,
+    recipient_user_id: Uuid,
+    server_cfg: &HttpServerConfig,
+    site_settings: &SiteSettings,
+) {
+    if let Err(err) = enqueue_attendance_canceled_notification(
+        event,
+        notifications_manager,
+        recipient_user_id,
+        server_cfg,
+        site_settings,
+    )
+    .await
+    {
+        warn!(error = %err, "failed to enqueue event attendance cancellation notification");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::anyhow;
+    use serde_json::from_value;
+    use uuid::Uuid;
+
+    use crate::{
+        config::HttpServerConfig,
+        handlers::tests::{sample_event_summary, sample_site_settings},
+        services::notifications::{DynNotificationsManager, MockNotificationsManager, NotificationKind},
+        templates::notifications::EventAttendanceCanceled,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_enqueue_attendance_canceled_notification_enqueues_expected_payload() {
+        // Setup identifiers and notification context
+        let event_id = Uuid::new_v4();
+        let group_id = Uuid::new_v4();
+        let recipient_user_id = Uuid::new_v4();
+        let event = sample_event_summary(event_id, group_id);
+        let site_settings = sample_site_settings();
+        let site_settings_for_notification = site_settings.clone();
+        let server_cfg = sample_server_cfg();
+
+        // Setup notifications manager mock
+        let mut notifications_manager = MockNotificationsManager::new();
+        notifications_manager
+            .expect_enqueue()
+            .times(1)
+            .withf(move |notification| {
+                matches!(notification.kind, NotificationKind::EventAttendanceCanceled)
+                    && notification.attachments.is_empty()
+                    && notification.recipients == vec![recipient_user_id]
+                    && notification.template_data.as_ref().is_some_and(|value| {
+                        from_value::<EventAttendanceCanceled>(value.clone()).is_ok_and(|template| {
+                            template.dashboard_link == "https://example.test/dashboard/user?tab=events"
+                                && template.event.event_id == event_id
+                                && template.link
+                                    == "https://example.test/test-community/group/def5678/event/ghi9abc"
+                                && template.theme.primary_color
+                                    == site_settings_for_notification.theme.primary_color
+                        })
+                    })
+            })
+            .returning(|_| Box::pin(async { Ok(()) }));
+        let notifications_manager: DynNotificationsManager = Arc::new(notifications_manager);
+
+        // Enqueue the notification
+        let result = enqueue_attendance_canceled_notification(
+            &event,
+            &notifications_manager,
+            recipient_user_id,
+            &server_cfg,
+            &site_settings,
+        )
+        .await;
+
+        // Check the helper succeeds
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_try_enqueue_attendance_canceled_notification_swallows_enqueue_errors() {
+        // Setup identifiers and notification context
+        let event = sample_event_summary(Uuid::new_v4(), Uuid::new_v4());
+        let recipient_user_id = Uuid::new_v4();
+        let server_cfg = sample_server_cfg();
+        let site_settings = sample_site_settings();
+
+        // Setup notifications manager mock
+        let mut notifications_manager = MockNotificationsManager::new();
+        notifications_manager
+            .expect_enqueue()
+            .times(1)
+            .returning(|_| Box::pin(async { Err(anyhow!("queue unavailable")) }));
+        let notifications_manager: DynNotificationsManager = Arc::new(notifications_manager);
+
+        // Try enqueueing and verify the caller is not failed
+        try_enqueue_attendance_canceled_notification(
+            &event,
+            &notifications_manager,
+            recipient_user_id,
+            &server_cfg,
+            &site_settings,
+        )
+        .await;
+    }
+
+    // Helpers.
+
+    fn sample_server_cfg() -> HttpServerConfig {
+        HttpServerConfig {
+            base_url: "https://example.test/".to_string(),
+            ..Default::default()
+        }
+    }
+}

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -262,6 +262,10 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             post(dashboard::group::attendees::invite_event_attendee),
         )
         .route(
+            "/events/{event_id}/attendees/{user_id}/attendance",
+            delete(dashboard::group::attendees::cancel_event_attendee_attendance),
+        )
+        .route(
             "/events/{event_id}/attendees/{user_id}/check-in",
             post(dashboard::group::attendees::manual_check_in),
         )
@@ -372,6 +376,10 @@ pub(super) fn setup_user_dashboard_router() -> Router<State> {
     Router::new()
         .route("/", get(dashboard::user::home::page))
         .route("/events", get(dashboard::user::events::list_page))
+        .route(
+            "/events/{community_name}/{event_id}/attendance",
+            delete(dashboard::user::events::cancel_attendance),
+        )
         .route("/invitations", get(dashboard::user::invitations::list_page))
         .route(
             "/invitations/community/{community_id}/accept",

--- a/ocg-server/src/services/notifications.rs
+++ b/ocg-server/src/services/notifications.rs
@@ -27,11 +27,12 @@ use crate::{
     config::EmailConfig,
     db::DynDB,
     templates::notifications::{
-        CfsSubmissionUpdated, CommunityTeamInvitation, EmailVerification, EventCanceled, EventCustom,
-        EventInvitation, EventPublished, EventRefundApproved, EventRefundRejected, EventRefundRequested,
-        EventReminder, EventRescheduled, EventSeriesCanceled, EventSeriesPublished, EventWaitlistJoined,
-        EventWaitlistLeft, EventWaitlistPromoted, EventWelcome, GroupCustom, GroupTeamInvitation,
-        GroupWelcome, SessionProposalCoSpeakerInvitation, SpeakerSeriesWelcome, SpeakerWelcome,
+        CfsSubmissionUpdated, CommunityTeamInvitation, EmailVerification, EventAttendanceCanceled,
+        EventCanceled, EventCustom, EventInvitation, EventPublished, EventRefundApproved,
+        EventRefundRejected, EventRefundRequested, EventReminder, EventRescheduled, EventSeriesCanceled,
+        EventSeriesPublished, EventWaitlistJoined, EventWaitlistLeft, EventWaitlistPromoted, EventWelcome,
+        GroupCustom, GroupTeamInvitation, GroupWelcome, SessionProposalCoSpeakerInvitation,
+        SpeakerSeriesWelcome, SpeakerWelcome,
     },
 };
 
@@ -331,6 +332,12 @@ impl DeliveryWorker {
             NotificationKind::EmailVerification => {
                 let subject = "Verify your email address".to_string();
                 let template: EmailVerification = serde_json::from_value(template_data)?;
+                let body = template.render()?;
+                (subject, body)
+            }
+            NotificationKind::EventAttendanceCanceled => {
+                let subject = "Attendance canceled".to_string();
+                let template: EventAttendanceCanceled = serde_json::from_value(template_data)?;
                 let body = template.render()?;
                 (subject, body)
             }
@@ -656,6 +663,8 @@ pub(crate) enum NotificationKind {
     CommunityTeamInvitation,
     /// Notification for email verification.
     EmailVerification,
+    /// Notification for a canceled event attendance.
+    EventAttendanceCanceled,
     /// Notification for an event canceled.
     EventCanceled,
     /// Notification for a custom event message.

--- a/ocg-server/src/services/notifications/tests.rs
+++ b/ocg-server/src/services/notifications/tests.rs
@@ -439,6 +439,28 @@ fn test_delivery_worker_prepare_content_email_verification() {
 }
 
 #[test]
+fn test_delivery_worker_prepare_content_event_attendance_canceled() {
+    // Setup notification
+    let notification = Notification {
+        attachments: vec![],
+        email: "user@example.test".to_string(),
+        kind: NotificationKind::EventAttendanceCanceled,
+        notification_id: Uuid::new_v4(),
+        template_data: Some(sample_event_attendance_canceled_template_data()),
+    };
+
+    // Prepare content
+    let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
+
+    // Check content matches expectations
+    assert_eq!(subject, "Attendance canceled");
+    assert!(body.contains("Your attendance for"));
+    assert!(body.contains("Reminder Event"));
+    assert!(body.contains("Open My Events"));
+    assert!(body.contains("https://example.test/dashboard/user?tab=events"));
+}
+
+#[test]
 fn test_delivery_worker_prepare_content_event_custom() {
     // Setup notification
     let notification = Notification {
@@ -543,6 +565,7 @@ fn test_delivery_worker_prepare_content_event_reminder() {
     assert_eq!(subject, "Reminder: Reminder Event starts in 24 hours");
     assert!(body.contains("Reminder Event"));
     assert!(body.contains("Use your registration name when joining."));
+    assert!(body.contains("If you can no longer attend"));
     assert!(body.contains("You received this email notification because you're attending or speaking at"));
     assert!(body.contains("Reminder Event"));
     assert!(body.contains("Notification Group"));
@@ -550,6 +573,7 @@ fn test_delivery_worker_prepare_content_event_reminder() {
     assert!(
         body.contains("https://example.test/test-community/group/notification-group/event/reminder-event")
     );
+    assert!(body.contains("https://example.test/dashboard/user?tab=events"));
 }
 
 #[test]
@@ -572,6 +596,29 @@ fn test_delivery_worker_prepare_content_event_reminder_legacy_template_data() {
     assert!(
         body.contains("https://example.test/test-community/group/notification-group/event/reminder-event")
     );
+}
+
+#[test]
+fn test_delivery_worker_prepare_content_event_reminder_speaker_only() {
+    // Setup notification
+    let mut template_data = sample_event_reminder_template_data();
+    template_data["show_attendance_cancellation_copy"] = json!(false);
+    let notification = Notification {
+        attachments: vec![],
+        email: "user@example.test".to_string(),
+        kind: NotificationKind::EventReminder,
+        notification_id: Uuid::new_v4(),
+        template_data: Some(template_data),
+    };
+
+    // Prepare content
+    let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
+
+    // Check content matches expectations
+    assert_eq!(subject, "Reminder: Reminder Event starts in 24 hours");
+    assert!(body.contains("You can review this event from the My Events section"));
+    assert!(!body.contains("If you can no longer attend"));
+    assert!(body.contains("https://example.test/dashboard/user?tab=events"));
 }
 
 #[test]
@@ -700,6 +747,49 @@ fn test_delivery_worker_prepare_content_event_waitlist_promoted() {
     assert!(body.contains("you are now registered"));
     assert!(body.contains("Use the waiting room display name from your ticket."));
     assert!(body.contains("Waitlist Event"));
+}
+
+#[test]
+fn test_delivery_worker_prepare_content_event_welcome_omits_dashboard_cancellation_guidance() {
+    // Setup notification
+    let notification = Notification {
+        attachments: vec![],
+        email: "user@example.test".to_string(),
+        kind: NotificationKind::EventWelcome,
+        notification_id: Uuid::new_v4(),
+        template_data: Some(sample_event_welcome_template_data(None)),
+    };
+
+    // Prepare content
+    let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
+
+    // Check content matches expectations
+    assert_eq!(subject, "Welcome to the event");
+    assert!(!body.contains("cancel your attendance from the My"));
+    assert!(!body.contains("Open My Events"));
+}
+
+#[test]
+fn test_delivery_worker_prepare_content_event_welcome_renders_dashboard_cancellation_guidance() {
+    // Setup notification
+    let notification = Notification {
+        attachments: vec![],
+        email: "user@example.test".to_string(),
+        kind: NotificationKind::EventWelcome,
+        notification_id: Uuid::new_v4(),
+        template_data: Some(sample_event_welcome_template_data(Some(
+            "https://example.test/dashboard/user?tab=events",
+        ))),
+    };
+
+    // Prepare content
+    let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
+
+    // Check content matches expectations
+    assert_eq!(subject, "Welcome to the event");
+    assert!(body.contains("cancel your attendance from the My"));
+    assert!(body.contains("Open My Events"));
+    assert!(body.contains("https://example.test/dashboard/user?tab=events"));
 }
 
 #[test]
@@ -941,6 +1031,36 @@ fn sample_email_verification_template_data() -> serde_json::Value {
     })
 }
 
+/// Sample template payload for event attendance cancellation notifications.
+fn sample_event_attendance_canceled_template_data() -> serde_json::Value {
+    json!({
+        "dashboard_link": "https://example.test/dashboard/user?tab=events",
+        "event": {
+            "canceled": false,
+            "community_display_name": "Test Community",
+            "community_name": "test-community",
+            "event_id": "11111111-1111-1111-1111-111111111111",
+            "group_category_name": "Community",
+            "group_name": "Notification Group",
+            "group_slug": "notification-group",
+            "kind": "hybrid",
+            "logo_url": "https://example.com/logo.png",
+            "name": "Reminder Event",
+            "published": true,
+            "slug": "reminder-event",
+            "starts_at": 1_914_724_800,
+            "timezone": "UTC",
+            "venue_name": "Conference Hall",
+            "waitlist_count": 0,
+            "waitlist_enabled": false
+        },
+        "link": "https://example.test/test-community/group/notification-group/event/reminder-event",
+        "theme": {
+            "primary_color": "#000000"
+        }
+    })
+}
+
 /// Sample template payload for custom event notifications.
 fn sample_event_custom_template_data() -> serde_json::Value {
     json!({
@@ -1027,6 +1147,7 @@ fn sample_event_reminder_legacy_template_data() -> serde_json::Value {
             "venue_name": "Conference Hall"
         },
         "link": "https://example.test/test-community/group/notification-group/event/reminder-event",
+        "show_attendance_cancellation_copy": true,
         "theme": {
             "primary_color": "#000000"
         }
@@ -1036,6 +1157,7 @@ fn sample_event_reminder_legacy_template_data() -> serde_json::Value {
 /// Sample template payload for event reminder notifications.
 fn sample_event_reminder_template_data() -> serde_json::Value {
     json!({
+        "show_attendance_cancellation_copy": true,
         "event": {
             "canceled": false,
             "community_display_name": "Test Community",
@@ -1056,6 +1178,7 @@ fn sample_event_reminder_template_data() -> serde_json::Value {
             "waitlist_count": 0,
             "waitlist_enabled": false
         },
+        "dashboard_link": "https://example.test/dashboard/user?tab=events",
         "link": "https://example.test/test-community/group/notification-group/event/reminder-event",
         "theme": {
             "primary_color": "#000000"
@@ -1150,6 +1273,38 @@ fn sample_event_waitlist_template_data() -> serde_json::Value {
             "primary_color": "#000000"
         }
     })
+}
+
+/// Sample template payload for event welcome notifications.
+fn sample_event_welcome_template_data(dashboard_link: Option<&str>) -> serde_json::Value {
+    let mut payload = json!({
+        "event": {
+            "canceled": false,
+            "community_display_name": "Test Community",
+            "community_name": "test-community",
+            "event_id": "11111111-1111-1111-1111-111111111111",
+            "group_category_name": "Community",
+            "group_name": "Notification Group",
+            "group_slug": "notification-group",
+            "kind": "hybrid",
+            "logo_url": "https://example.com/logo.png",
+            "name": "Welcome Event",
+            "published": true,
+            "slug": "welcome-event",
+            "starts_at": 1_914_724_800,
+            "timezone": "UTC",
+            "venue_name": "Conference Hall",
+            "waitlist_count": 0,
+            "waitlist_enabled": false
+        },
+        "link": "https://example.test/test-community/group/notification-group/event/welcome-event",
+        "theme": {
+            "primary_color": "#000000"
+        }
+    });
+    let object = payload.as_object_mut().expect("event welcome payload is an object");
+    object.insert("dashboard_link".to_string(), json!(dashboard_link));
+    payload
 }
 
 /// Sample template payload for custom group notifications.

--- a/ocg-server/src/services/payments/notification_composer.rs
+++ b/ocg-server/src/services/payments/notification_composer.rs
@@ -12,8 +12,11 @@ use crate::{
     templates::notifications::{
         EventRefundApproved, EventRefundRejected, EventRefundRequested, EventWelcome,
     },
-    util::{build_event_calendar_attachment, build_event_page_link},
+    util::{build_event_calendar_attachment, build_event_page_link, build_user_dashboard_events_link},
 };
+
+#[cfg(test)]
+mod tests;
 
 /// Composes and enqueues notifications for payments workflows.
 #[derive(Clone)]
@@ -22,9 +25,6 @@ pub(super) struct PaymentsNotificationComposer {
     notifications_manager: DynNotificationsManager,
     server_cfg: HttpServerConfig,
 }
-
-#[cfg(test)]
-mod tests;
 
 impl PaymentsNotificationComposer {
     /// Create a new payments notification composer.
@@ -68,25 +68,43 @@ impl PaymentsNotificationComposer {
         .map_err(Into::into)
     }
 
-    /// Enqueue the attendee welcome notification for a completed checkout.
+    /// Enqueue the attendee welcome notification for a completed provider checkout.
     pub(super) async fn enqueue_checkout_completed_notification(
         &self,
         completed_purchase: CompletedEventPurchase,
     ) {
-        self.enqueue_event_welcome_notification(
+        self.enqueue_event_welcome_notification_with_self_service(
             completed_purchase.community_id,
             completed_purchase.event_id,
             completed_purchase.user_id,
+            EventWelcomeSelfService::EventPageRefund,
         )
         .await;
     }
 
-    /// Enqueue the attendee welcome notification after a successful ticket purchase.
+    /// Enqueue the attendee welcome notification with dashboard cancellation guidance.
     pub(super) async fn enqueue_event_welcome_notification(
         &self,
         community_id: Uuid,
         event_id: Uuid,
         user_id: Uuid,
+    ) {
+        self.enqueue_event_welcome_notification_with_self_service(
+            community_id,
+            event_id,
+            user_id,
+            EventWelcomeSelfService::DashboardCancellation,
+        )
+        .await;
+    }
+
+    /// Enqueue the attendee welcome notification with context-specific self-service guidance.
+    async fn enqueue_event_welcome_notification_with_self_service(
+        &self,
+        community_id: Uuid,
+        event_id: Uuid,
+        user_id: Uuid,
+        self_service: EventWelcomeSelfService,
     ) {
         // Skip notification delivery when the event context cannot be loaded
         let Some((event, site_settings)) = self
@@ -98,6 +116,12 @@ impl PaymentsNotificationComposer {
 
         // Build the attendee-facing welcome notification and calendar attachment
         let base_url = self.base_url();
+        let dashboard_link = match self_service {
+            EventWelcomeSelfService::DashboardCancellation => {
+                Some(build_user_dashboard_events_link(base_url))
+            }
+            EventWelcomeSelfService::EventPageRefund => None,
+        };
         let link = build_event_page_link(base_url, &event);
         let notification = NewNotification {
             attachments: vec![build_event_calendar_attachment(base_url, &event)],
@@ -107,6 +131,8 @@ impl PaymentsNotificationComposer {
                 event,
                 link,
                 theme: site_settings.theme,
+
+                dashboard_link,
             })
             .ok(),
         };
@@ -216,4 +242,13 @@ impl PaymentsNotificationComposer {
             }
         }
     }
+}
+
+/// Self-service guidance shown in event welcome notifications.
+#[derive(Debug, Clone, Copy)]
+enum EventWelcomeSelfService {
+    /// Attendees can cancel from the My Events dashboard.
+    DashboardCancellation,
+    /// Attendees currently manage paid ticket refunds from the event page.
+    EventPageRefund,
 }

--- a/ocg-server/src/services/payments/notification_composer/tests.rs
+++ b/ocg-server/src/services/payments/notification_composer/tests.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     config::HttpServerConfig,
-    db::mock::MockDB,
+    db::{mock::MockDB, payments::CompletedEventPurchase},
     services::notifications::{MockNotificationsManager, NotificationKind},
     templates::notifications::{
         EventRefundApproved, EventRefundRejected, EventRefundRequested, EventWelcome,
@@ -56,6 +56,57 @@ async fn build_refund_request_template_data_returns_expected_payload() {
 }
 
 #[tokio::test]
+async fn enqueue_checkout_completed_notification_omits_dashboard_cancel_guidance() {
+    // Setup identifiers and data structures
+    let community_id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let event = sample_event_summary(event_id);
+    let site_settings = SiteSettings::default();
+    let user_id = Uuid::new_v4();
+    let expected_template_data = to_value(&EventWelcome {
+        event: sample_event_summary(event_id),
+        link: "/community/group/group/event/event".to_string(),
+        theme: SiteSettings::default().theme,
+
+        dashboard_link: None,
+    })
+    .unwrap();
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_get_event_summary_by_id()
+        .times(1)
+        .withf(move |cid, eid| *cid == community_id && *eid == event_id)
+        .returning(move |_, _| Ok(event.clone()));
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(move || Ok(site_settings.clone()));
+
+    // Setup notifications manager mock
+    let mut notifications_manager = MockNotificationsManager::new();
+    notifications_manager
+        .expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            notification.attachments.len() == 1
+                && matches!(notification.kind, NotificationKind::EventWelcome)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref() == Some(&expected_template_data)
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
+
+    // Enqueue the checkout completed welcome notification
+    let composer = sample_notification_composer(db, notifications_manager);
+    composer
+        .enqueue_checkout_completed_notification(CompletedEventPurchase {
+            community_id,
+            event_id,
+            user_id,
+        })
+        .await;
+}
+
+#[tokio::test]
 async fn enqueue_event_welcome_notification_enqueues_expected_payload() {
     // Setup identifiers and data structures
     let community_id = Uuid::new_v4();
@@ -67,6 +118,8 @@ async fn enqueue_event_welcome_notification_enqueues_expected_payload() {
         event: sample_event_summary(event_id),
         link: "/community/group/group/event/event".to_string(),
         theme: SiteSettings::default().theme,
+
+        dashboard_link: Some("/dashboard/user?tab=events".to_string()),
     })
     .unwrap();
 

--- a/ocg-server/src/templates/dashboard/audit.rs
+++ b/ocg-server/src/templates/dashboard/audit.rs
@@ -149,6 +149,11 @@ const AUDIT_ACTION_DEFINITIONS: &[AuditActionDefinition] = &[
         value: "event_added",
     },
     AuditActionDefinition {
+        label: "Event attendance canceled",
+        scopes: GROUP_SCOPES,
+        value: "event_attendee_attendance_canceled",
+    },
+    AuditActionDefinition {
         label: "Event attendee checked in",
         scopes: GROUP_SCOPES,
         value: "event_attendee_checked_in",

--- a/ocg-server/src/templates/dashboard/group/attendees.rs
+++ b/ocg-server/src/templates/dashboard/group/attendees.rs
@@ -135,6 +135,12 @@ pub(crate) struct AttendeesOutput {
 
 // Helpers.
 
+/// Returns true when the attendee has a paid event purchase.
+#[allow(clippy::ref_option)]
+pub(crate) fn is_paid_attendee(amount_minor: &Option<i64>) -> bool {
+    matches!(*amount_minor, Some(amount_minor) if amount_minor > 0)
+}
+
 /// Format an attendee payment amount for display.
 #[allow(clippy::ref_option)]
 pub(crate) fn format_payment_amount(

--- a/ocg-server/src/templates/dashboard/user/events.rs
+++ b/ocg-server/src/templates/dashboard/user/events.rs
@@ -39,6 +39,9 @@ pub(crate) struct ListPage {
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct UserEvent {
+    /// Whether the user can cancel attendance from this row.
+    #[serde(default)]
+    pub can_cancel_attendance: bool,
     /// Event summary data.
     pub event: EventSummary,
     /// Roles the user has in the event.

--- a/ocg-server/src/templates/notifications.rs
+++ b/ocg-server/src/templates/notifications.rs
@@ -46,6 +46,20 @@ pub(crate) struct EmailVerification {
     pub theme: Theme,
 }
 
+/// Template for event attendance canceled notification.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "notifications/event_attendance_canceled.html")]
+pub(crate) struct EventAttendanceCanceled {
+    /// Link to the user dashboard events page.
+    pub dashboard_link: String,
+    /// Event summary data.
+    pub event: EventSummary,
+    /// Link to the event page.
+    pub link: String,
+    /// Theme configuration for the community.
+    pub theme: Theme,
+}
+
 /// Template for event canceled notification.
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "notifications/event_canceled.html")]
@@ -152,8 +166,14 @@ pub(crate) struct EventReminder {
     pub event: EventSummary,
     /// Link to the event page.
     pub link: String,
+    /// Whether to show attendance cancellation copy.
+    pub show_attendance_cancellation_copy: bool,
     /// Theme configuration for the community.
     pub theme: Theme,
+
+    /// Link to the user dashboard events page.
+    #[serde(default)]
+    pub dashboard_link: Option<String>,
 }
 
 /// Template for event rescheduled notification.
@@ -238,12 +258,16 @@ pub(crate) struct EventWaitlistPromoted {
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "notifications/event_welcome.html")]
 pub(crate) struct EventWelcome {
-    /// Link to the event page.
-    pub link: String,
     /// Event summary data.
     pub event: EventSummary,
+    /// Link to the event page.
+    pub link: String,
     /// Theme configuration for the community.
     pub theme: Theme,
+
+    /// Link to the user dashboard events page.
+    #[serde(default)]
+    pub dashboard_link: Option<String>,
 }
 
 /// Template for group custom notification.

--- a/ocg-server/src/util.rs
+++ b/ocg-server/src/util.rs
@@ -130,6 +130,12 @@ pub(crate) fn build_event_page_link(base_url: &str, event: &EventSummary) -> Str
     )
 }
 
+/// Build the user dashboard events link.
+pub(crate) fn build_user_dashboard_events_link(base_url: &str) -> String {
+    let base = base_url.strip_suffix('/').unwrap_or(base_url);
+    format!("{base}/dashboard/user?tab=events")
+}
+
 /// Computes the SHA-256 hash of the provided bytes and returns a hex string.
 pub(crate) fn compute_hash(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();

--- a/ocg-server/static/js/common/breadcrumb-nav.js
+++ b/ocg-server/static/js/common/breadcrumb-nav.js
@@ -270,7 +270,7 @@ export class BreadcrumbNav extends LitWrapper {
 
             <!-- Desktop breadcrumb -->
             <ol
-              class="hidden sm:flex sm:items-center gap-2 text-sm text-stone-500"
+              class="hidden sm:flex sm:items-center gap-2 text-sm text-stone-500 px-1"
               style="--breadcrumb-count: ${breadcrumbCount};"
             >
               ${this.items.map((item, index) => this._renderDesktopItem(item, index))}

--- a/ocg-server/templates/dashboard/group/attendees_list.html
+++ b/ocg-server/templates/dashboard/group/attendees_list.html
@@ -258,7 +258,8 @@
             <td class="px-3 xl:px-5 py-4 w-[72px] text-right">
               <div class="relative inline-flex justify-end">
                 {% if can_manage_events
-                  && (attendee.status == "invitation-pending"
+                  && (attendee.status == "confirmed"
+                  || attendee.status == "invitation-pending"
                   || attendee.refund_request_status == Some(crate::types::payments::EventRefundRequestStatus::Pending)
                   || attendee.refund_request_status == Some(crate::types::payments::EventRefundRequestStatus::Approving)) -%}
                   <details data-attendee-row-actions-menu class="group relative">
@@ -286,6 +287,26 @@
                                     type="button">
                               <div class="svg-icon size-4 icon-cancel shrink-0 bg-stone-500"></div>
                               <span>Cancel invitation</span>
+                            </button>
+                          </li>
+                        {% endif -%}
+                        {% if attendee.status == "confirmed" -%}
+                          <li>
+                            <button id="cancel-attendance-{{ attendee.user_id }}"
+                                    {% if !self::is_paid_attendee(attendee.amount_minor) && !event.canceled && !event.is_past() -%}
+                                      hx-delete="/dashboard/group/events/{{ event.event_id }}/attendees/{{ attendee.user_id }}/attendance" hx-indicator="#dashboard-spinner" hx-trigger="confirmed" hx-disabled-elt="this" data-confirm-action data-confirm-message="Are you sure you want to cancel this attendance?" data-confirm-text="Yes" data-success-message="Attendance canceled." data-error-message="Something went wrong canceling this attendance. Please try again later."
+                                    {% else if self::is_paid_attendee(attendee.amount_minor) -%}
+                                      disabled title="Paid attendee attendance cannot be canceled from attendee actions."
+                                    {% else if event.canceled -%}
+                                      disabled title="Canceled event attendance cannot be canceled."
+                                    {% else -%}
+                                      disabled title="Past event attendance cannot be canceled."
+                                    {% endif -%}
+                                    role="menuitem"
+                                    class="flex items-center w-full px-4 py-2 hover:bg-stone-100 hover:text-stone-900 transition-colors gap-3 text-left disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white disabled:hover:text-stone-700"
+                                    type="button">
+                              <div class="svg-icon size-4 icon-cancel shrink-0 bg-stone-500"></div>
+                              <span>Cancel attendance</span>
                             </button>
                           </li>
                         {% endif -%}

--- a/ocg-server/templates/dashboard/user/events_list.html
+++ b/ocg-server/templates/dashboard/user/events_list.html
@@ -19,17 +19,20 @@ description = "Upcoming events where you'll participate.") -}}
         <th scope="col" class="hidden 2xl:table-cell px-3 xl:px-5 py-3">Location</th>
         <th scope="col" class="hidden xl:table-cell px-3 xl:px-5 py-3 w-40">Date</th>
         <th scope="col" class="px-3 xl:px-5 py-3 w-64">Role</th>
+        <th scope="col" class="px-3 xl:px-5 py-3 w-[72px]">
+          <span class="sr-only">Actions</span>
+        </th>
       </tr>
     </thead>
     <tbody>
       {% if events.is_empty() -%}
         <tr class="bg-white border-b border-stone-200">
-          <td class="xl:hidden px-8 py-20 text-center" colspan="2">
+          <td class="xl:hidden px-8 py-20 text-center" colspan="3">
             {% include "dashboard/placeholders/user_events_table.html" -%}
           </td>
           <td class="hidden xl:table-cell 2xl:hidden px-8 py-20 text-center"
-              colspan="3">{% include "dashboard/placeholders/user_events_table.html" -%}</td>
-          <td class="hidden 2xl:table-cell px-8 py-20 text-center" colspan="4">
+              colspan="4">{% include "dashboard/placeholders/user_events_table.html" -%}</td>
+          <td class="hidden 2xl:table-cell px-8 py-20 text-center" colspan="5">
             {% include "dashboard/placeholders/user_events_table.html" -%}
           </td>
         </tr>
@@ -96,6 +99,34 @@ description = "Upcoming events where you'll participate.") -}}
                   {{ badges::common_badge(content = role, extra_styles = Some("px-2.5 py-0.5") ) -}}
                 {% endfor -%}
               </div>
+            </td>
+
+            <td class="px-3 xl:px-5 py-4 w-[72px] text-right">
+              <details class="group relative inline-flex justify-end">
+                <summary class="btn-actions btn-tertiary flex cursor-pointer list-none items-center justify-center p-2 group-open:bg-stone-50 [&::-webkit-details-marker]:hidden"
+                         aria-label="Open event actions"
+                         title="Open event actions">
+                  <div class="svg-icon size-4 icon-vertical-dots"></div>
+                </summary>
+                <div class="dropdown absolute z-10 end-0 top-8 w-[220px] bg-white divide-y divide-stone-100 rounded-lg shadow border border-stone-200">
+                  <ul class="py-2 text-sm text-stone-700" role="menu">
+                    <li>
+                      <button id="cancel-attendance-{{ item.event.event_id }}"
+                              {% if item.can_cancel_attendance -%}
+                                hx-delete="/dashboard/user/events/{{ item.event.community_name }}/{{ item.event.event_id }}/attendance" hx-indicator="#dashboard-spinner" hx-trigger="confirmed" hx-disabled-elt="this" data-confirm-action data-confirm-message="Are you sure you want to cancel your attendance?" data-confirm-text="Yes" data-success-message="You have successfully canceled your attendance." data-error-message="Something went wrong canceling your attendance. Please try again later."
+                              {% else -%}
+                                disabled title="Only attendee attendance can be canceled."
+                              {% endif -%}
+                              role="menuitem"
+                              class="flex items-center w-full px-4 py-2 hover:bg-stone-100 hover:text-stone-900 transition-colors gap-3 text-left disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white disabled:hover:text-stone-700"
+                              type="button">
+                        <div class="svg-icon size-4 icon-cancel shrink-0 bg-stone-500"></div>
+                        <span>Cancel attendance</span>
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </details>
             </td>
           </tr>
         {% endfor -%}

--- a/ocg-server/templates/notifications/event_attendance_canceled.html
+++ b/ocg-server/templates/notifications/event_attendance_canceled.html
@@ -1,0 +1,37 @@
+{% extends "notifications/base.html" -%}
+{% import "macros/email.html" as email -%}
+
+{% block subject -%}
+  Attendance canceled: {{ event.name }}
+{% endblock subject -%}
+
+{% block preheader -%}
+  Your attendance for {{ event.name }} has been canceled.
+{% endblock preheader -%}
+
+{% block content -%}
+  <div class="default mb-30" style="margin-bottom: 30px">
+    Your attendance for <strong>{{ event.name }}</strong> with
+    <strong>{{ event.group_name }}</strong> has been canceled.
+    <br />
+    <br />
+    You are no longer registered for this event. If registration is still
+    available, you can register again from the event page.
+  </div>
+
+  {{ email::button(link = link, text = "View event", color = theme.primary_color) }}
+
+  <p class="default mt-30 mb-15"
+     style="margin-top: 30px;
+            margin-bottom: 15px">
+    You can review upcoming events from the My Events section in your dashboard.
+  </p>
+
+  {{ email::button(link = dashboard_link, text = "Open My Events", color = theme.primary_color) }}
+{% endblock content -%}
+
+{% block footer -%}
+  You received this email notification because your attendance to
+  {{ event.name }}, an event from {{ event.group_name }} in the
+  {{ event.community_display_name }} community, was canceled.
+{% endblock footer -%}

--- a/ocg-server/templates/notifications/event_reminder.html
+++ b/ocg-server/templates/notifications/event_reminder.html
@@ -50,6 +50,21 @@
   </div>
 
   {{ email::button(link = link, text = "View event", color = theme.primary_color) }}
+
+  {% if let Some(dashboard_link) = &dashboard_link -%}
+    <p class="default mt-30 mb-15"
+       style="margin-top: 30px;
+              margin-bottom: 15px">
+      {% if show_attendance_cancellation_copy -%}
+        If you can no longer attend, you can cancel your attendance from the My
+        Events section in your dashboard.
+      {% else -%}
+        You can review this event from the My Events section in your dashboard.
+      {% endif -%}
+    </p>
+
+    {{ email::button(link = dashboard_link, text = "Open My Events", color = theme.primary_color) }}
+  {% endif -%}
 {% endblock content -%}
 
 {% block footer -%}

--- a/ocg-server/templates/notifications/event_welcome.html
+++ b/ocg-server/templates/notifications/event_welcome.html
@@ -55,6 +55,17 @@
 
   {{ email::button(link = link, text = "View event", color = theme.primary_color) }}
 
+  {% if let Some(dashboard_link) = &dashboard_link -%}
+    <p class="default mt-30 mb-15"
+       style="margin-top: 30px;
+              margin-bottom: 15px">
+      If you can no longer attend, you can cancel your attendance from the My
+      Events section in your dashboard.
+    </p>
+
+    {{ email::button(link = dashboard_link, text = "Open My Events", color = theme.primary_color) }}
+  {% endif -%}
+
   <p class="default mt-30 mb-15"
      style="margin-top: 30px;
             margin-bottom: 15px">

--- a/tests/e2e/dashboard/group/events/attendees.spec.ts
+++ b/tests/e2e/dashboard/group/events/attendees.spec.ts
@@ -453,7 +453,7 @@ test.describe("group dashboard attendees tab", () => {
       await expect(rowActionsMenu.getByRole("menuitem", { name: "Reject refund" })).toHaveCount(0);
     });
 
-    test("organizer sees rejected refunds as a read-only attendee badge", async ({
+    test("organizer sees rejected refunds with disabled attendance cancellation", async ({
       organizerGroupPage,
     }) => {
       const attendeesContent = await openAttendeesTab(
@@ -464,12 +464,22 @@ test.describe("group dashboard attendees tab", () => {
       const attendeeRow = attendeesContent.locator("tr", {
         hasText: "E2E Pending One",
       });
+      const rowActionsMenu = attendeeRow.locator("[data-attendee-row-actions-menu]");
 
       await expect(attendeeRow.getByText("Refund rejected", { exact: true })).toBeVisible();
-      await expect(attendeeRow.locator("[data-attendee-row-actions-menu]")).toHaveCount(0);
+      await expect(rowActionsMenu).toBeVisible();
+      await rowActionsMenu.locator("summary").click();
+      const cancelAttendance = rowActionsMenu.getByRole("menuitem", {
+        name: "Cancel attendance",
+      });
+      await expect(cancelAttendance).toBeDisabled();
+      await expect(cancelAttendance).toHaveAttribute(
+        "title",
+        "Paid attendee attendance cannot be canceled from attendee actions.",
+      );
     });
 
-    test("organizer sees approved refunds as a read-only attendee badge", async ({
+    test("organizer sees approved refunds with disabled attendance cancellation", async ({
       organizerGroupPage,
     }) => {
       const attendeesContent = await openAttendeesTab(
@@ -480,9 +490,19 @@ test.describe("group dashboard attendees tab", () => {
       const attendeeRow = attendeesContent.locator("tr", {
         hasText: "E2E Group Viewer One",
       });
+      const rowActionsMenu = attendeeRow.locator("[data-attendee-row-actions-menu]");
 
       await expect(attendeeRow.getByText("Refund approved", { exact: true })).toBeVisible();
-      await expect(attendeeRow.locator("[data-attendee-row-actions-menu]")).toHaveCount(0);
+      await expect(rowActionsMenu).toBeVisible();
+      await rowActionsMenu.locator("summary").click();
+      const cancelAttendance = rowActionsMenu.getByRole("menuitem", {
+        name: "Cancel attendance",
+      });
+      await expect(cancelAttendance).toBeDisabled();
+      await expect(cancelAttendance).toHaveAttribute(
+        "title",
+        "Paid attendee attendance cannot be canceled from attendee actions.",
+      );
     });
 
     test("viewer cannot review or approve attendee refunds", async ({

--- a/tests/unit/dashboard/group/attendees-list-template.test.js
+++ b/tests/unit/dashboard/group/attendees-list-template.test.js
@@ -1,0 +1,42 @@
+import { expect } from "@open-wc/testing";
+
+const loadTemplate = async () => {
+  const response = await fetch("/ocg-server/templates/dashboard/group/attendees_list.html");
+
+  expect(response.ok).to.equal(true);
+
+  return response.text();
+};
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, " ").trim();
+
+describe("dashboard group attendees list template", () => {
+  it("renders cancel attendance as a confirmed delete action for eligible attendees", async () => {
+    const template = normalizeWhitespace(await loadTemplate());
+
+    expect(template).to.include('attendee.status == "confirmed"');
+    expect(template).to.include('id="cancel-attendance-{{ attendee.user_id }}"');
+    expect(template).to.include(
+      'hx-delete="/dashboard/group/events/{{ event.event_id }}/attendees/{{ attendee.user_id }}/attendance"',
+    );
+    expect(template).to.include('hx-trigger="confirmed"');
+    expect(template).to.include('hx-disabled-elt="this"');
+    expect(template).to.include("data-confirm-action");
+    expect(template).to.include('data-confirm-message="Are you sure you want to cancel this attendance?"');
+    expect(template).to.include('data-success-message="Attendance canceled."');
+    expect(template).to.include(
+      'data-error-message="Something went wrong canceling this attendance. Please try again later."',
+    );
+  });
+
+  it("keeps cancel attendance disabled for unsupported attendee states", async () => {
+    const template = normalizeWhitespace(await loadTemplate());
+
+    expect(template).to.include("!self::is_paid_attendee(attendee.amount_minor)");
+    expect(template).to.include("!event.canceled");
+    expect(template).to.include("!event.is_past()");
+    expect(template).to.include('title="Paid attendee attendance cannot be canceled from attendee actions."');
+    expect(template).to.include('title="Canceled event attendance cannot be canceled."');
+    expect(template).to.include('title="Past event attendance cannot be canceled."');
+  });
+});

--- a/tests/unit/dashboard/user/events-list-template.test.js
+++ b/tests/unit/dashboard/user/events-list-template.test.js
@@ -1,0 +1,43 @@
+import { expect } from "@open-wc/testing";
+
+const loadTemplate = async () => {
+  const response = await fetch("/ocg-server/templates/dashboard/user/events_list.html");
+
+  expect(response.ok).to.equal(true);
+
+  return response.text();
+};
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, " ").trim();
+
+describe("dashboard user events list template", () => {
+  it("renders cancel attendance as a confirmed delete action when cancellation is allowed", async () => {
+    const template = normalizeWhitespace(await loadTemplate());
+
+    expect(template).to.include("<span>Cancel attendance</span>");
+    expect(template).to.include('id="cancel-attendance-{{ item.event.event_id }}"');
+    expect(template).to.include("{% if item.can_cancel_attendance -%}");
+    expect(template).to.include(
+      'hx-delete="/dashboard/user/events/{{ item.event.community_name }}/{{ item.event.event_id }}/attendance"',
+    );
+    expect(template).to.include('hx-trigger="confirmed"');
+    expect(template).to.include('hx-disabled-elt="this"');
+    expect(template).to.include("data-confirm-action");
+    expect(template).to.include('data-confirm-message="Are you sure you want to cancel your attendance?"');
+    expect(template).to.include(
+      'data-success-message="You have successfully canceled your attendance."',
+    );
+    expect(template).to.include(
+      'data-error-message="Something went wrong canceling your attendance. Please try again later."',
+    );
+  });
+
+  it("keeps cancel attendance visible but disabled when cancellation is unavailable", async () => {
+    const template = normalizeWhitespace(await loadTemplate());
+
+    expect(template).to.include("disabled");
+    expect(template).to.include('title="Only attendee attendance can be canceled."');
+    expect(template).to.include('<span class="sr-only">Actions</span>');
+    expect(template).to.include('aria-label="Open event actions"');
+  });
+});


### PR DESCRIPTION
- Allow users to cancel their attendance from `My Events` tab in the user dashboard
- Allow groups' admin to cancel attendance from the group dashboard (attendees list)
- Add link to email notifications to make it easier to cancel attendance