### PR TITLE
Add "add to calendar" options on event page

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -57,7 +57,9 @@ membership cleanly.
 From the group page or explore results, open an event and click `Attend event`.
 This records your attendance intent and is the basis for event-day check-in.
 After you RSVP, OCG sends a confirmation message with a calendar attachment.
-For live virtual/hybrid events that have meeting information configured,
+You can also add the event to your own calendar any time from the event
+page's actions menu (`⋮`), via `Add to Google Calendar` or `Download .ics
+file`. For live virtual/hybrid events that have meeting information configured,
 attendees can also get `Join meeting` access at the right time window.
 
 If the event is already full, you may instead see `Join waiting list` when

--- a/docs/guides/public-site.md
+++ b/docs/guides/public-site.md
@@ -100,6 +100,8 @@ A few details shape how RSVP behaves:
   ticket hold, you can complete payment and required registration questions until the hold expires.
 - Canceling RSVP is immediate through `Cancel attendance`.
 - After RSVP, OCG sends a confirmation message with a calendar file attached.
+- The event page's actions menu (`⋮`) offers `Add to Google Calendar` and
+  `Download .ics file` at any time, independent of RSVP status.
 - If organizers configured registration questions, clicking `Attend event` or `Buy ticket` opens
   a question form first. Required answers must be completed before registration can continue.
 - Some events use invitation review. In that case, `Attend event` becomes

--- a/ocg-server/src/handlers/event.rs
+++ b/ocg-server/src/handlers/event.rs
@@ -185,6 +185,34 @@ pub(crate) async fn check_in_page(
     Ok(Html(template.render()?))
 }
 
+/// Handler that returns the event's iCalendar (ICS) file for download.
+#[instrument(skip_all, err)]
+pub(crate) async fn calendar_ics(
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    CommunityId(community_id): CommunityId,
+    Path((_, event_id)): Path<(String, Uuid)>,
+) -> Result<impl IntoResponse, HandlerError> {
+    // Get event summary and build the calendar attachment
+    let event = db.get_event_summary_by_id(community_id, event_id).await?;
+    let attachment = crate::util::build_event_calendar_attachment(&server_cfg.base_url, &event);
+
+    // Serve the attachment as a file download
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        HeaderValue::from_str(&attachment.content_type).map_err(anyhow::Error::from)?,
+    );
+    headers.insert(
+        axum::http::header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{}\"", attachment.file_name))
+            .map_err(anyhow::Error::from)?,
+    );
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static(CACHE_CONTROL_NO_STORE));
+
+    Ok((headers, attachment.data).into_response())
+}
+
 // JSON handlers.
 
 /// Handler that returns fresh public availability for the event page.

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -278,6 +278,10 @@ pub(crate) async fn setup(
             get(event::cfs_modal),
         )
         .route(
+            "/{community}/event/{event_id}/calendar.ics",
+            get(event::calendar_ics),
+        )
+        .route(
             "/{community}/group/{group_slug}/event/{event_slug}/availability",
             get(event::availability),
         )

--- a/ocg-server/src/templates/event.rs
+++ b/ocg-server/src/templates/event.rs
@@ -1,7 +1,8 @@
 //! This module defines the templates for the event page.
 
 use askama::Template;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Duration, Timelike, Utc};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use uuid::Uuid;
@@ -52,6 +53,47 @@ impl Page {
                 self.event.slug
             ),
         )
+    }
+
+    /// Returns the download URL for the event's iCalendar (ICS) file.
+    pub(crate) fn calendar_ics_url(&self) -> String {
+        format!(
+            "/{}/event/{}/calendar.ics",
+            self.event.community.name, self.event.event_id
+        )
+    }
+
+    /// Returns a Google Calendar "add event" link for the event.
+    pub(crate) fn google_calendar_link(&self) -> Option<String> {
+        let start = self.event.starts_at?;
+        let end = self.event.ends_at.unwrap_or(start + Duration::hours(1));
+
+        let mut details = String::new();
+        if let Some(description_short) = self
+            .event
+            .description_short
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            details.push_str(description_short.trim());
+            details.push_str("\n\n");
+        }
+        details.push_str(&self.canonical_url());
+
+        let mut url = format!(
+            "https://calendar.google.com/calendar/render?action=TEMPLATE&text={}&dates={}/{}&details={}&ctz={}",
+            encode_for_url(&self.event.name),
+            format_datetime_for_google_calendar(&start),
+            format_datetime_for_google_calendar(&end),
+            encode_for_url(&details),
+            encode_for_url(&self.event.timezone.to_string()),
+        );
+        if let Some(location) = self.event.location(512) {
+            url.push_str("&location=");
+            url.push_str(&encode_for_url(&location));
+        }
+
+        Some(url)
     }
 
     /// Returns the Open Graph image URL for the event page.
@@ -157,6 +199,24 @@ pub(crate) struct SessionProposal {
     /// Proposal last update time.
     #[serde(default, with = "chrono::serde::ts_seconds_option")]
     pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Percent-encodes a value for use in a URL query string.
+fn encode_for_url(value: &str) -> String {
+    utf8_percent_encode(value, NON_ALPHANUMERIC).to_string()
+}
+
+/// Formats a UTC datetime for the Google Calendar `dates` query parameter (YYYYMMDDTHHMMSSZ).
+fn format_datetime_for_google_calendar(dt: &DateTime<Utc>) -> String {
+    format!(
+        "{:04}{:02}{:02}T{:02}{:02}{:02}Z",
+        dt.year(),
+        dt.month(),
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second()
+    )
 }
 
 #[cfg(test)]

--- a/ocg-server/templates/event/attend_button.html
+++ b/ocg-server/templates/event/attend_button.html
@@ -432,6 +432,23 @@
       <div class="absolute left-4 z-20 mt-2 w-56 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-stone-200 bg-white py-1 shadow-lg sm:left-auto sm:right-0 sm:w-max sm:min-w-48">
         <share-modal trigger-variant="menu-item" title="{{ event.group.name }} · {{ event.name }}" url="/{{ event.community.name }}/group/{{ event.group.public_slug() }}/event/{{ event.slug }}">
         </share-modal>
+        {% if let Some(google_calendar_link) = self.google_calendar_link() -%}
+          <a id="add-to-google-calendar-btn-{{ attendance_instance }}"
+             href="{{ google_calendar_link }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="group flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-stone-700 hover:bg-stone-50">
+            <div class="svg-icon size-4 bg-stone-600 icon-calendar"></div>
+            <span>Add to Google Calendar</span>
+          </a>
+        {% endif -%}
+        <a id="download-ics-btn-{{ attendance_instance }}"
+           href="{{ self.calendar_ics_url() }}"
+           download
+           class="group flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-stone-700 hover:bg-stone-50">
+          <div class="svg-icon size-4 bg-stone-600 icon-calendar"></div>
+          <span>Download .ics file</span>
+        </a>
         {% if let Some(meeting_join_url) = &event.meeting_join_url %}
           <a id="join-meeting-menu-btn-{{ attendance_instance }}"
              data-attendance-role="join-meeting-menu-btn"


### PR DESCRIPTION
## Summary
- Attendees previously only got a calendar file via email after RSVP. This
  adds an `Add to Google Calendar` link and a `Download .ics file` option to
  the event page's actions menu (`⋮`), available any time, independent of
  RSVP status.
- New public route `GET /{community}/event/{event_id}/calendar.ics` serves
  the event's iCalendar file, reusing the existing
  `build_event_calendar_attachment` used for notification emails.
- New `Page::google_calendar_link()` builds a `calendar.google.com` "add
  event" link (title, dates, details, location, timezone), added alongside
  `Page::calendar_ics_url()` in `templates/event.rs`.
- Docs updated (`docs/guides/public-site.md`,
  `docs/getting-started/quickstart.md`) to mention the new menu items.

## Test plan
- [ ] `cargo build` / `cargo test` pass
- [ ] Load an event page, open the `⋮` actions menu, confirm `Add to Google
      Calendar` and `Download .ics file` appear
- [ ] Click `Add to Google Calendar` opens Google Calendar prefilled with
      event title, date/time, location, and link back to event page
- [ ] Click `Download .ics file` downloads a valid `.ics` file that opens
      correctly in a calendar app
- [ ] Verify both options work for a logged-out visitor (no RSVP required)
