### PR TITLE
Localize event page times to each user's timezone

### DIFF
--- a/ocg-server/src/handlers/auth/tests.rs
+++ b/ocg-server/src/handlers/auth/tests.rs
@@ -199,7 +199,11 @@ async fn test_user_menu_section_success() {
     db.expect_get_user_by_id()
         .times(1)
         .withf(move |id| *id == user_id)
-        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
+        .returning(move |_| {
+            let mut user = sample_auth_user(user_id, &auth_hash);
+            user.timezone = Some("America/Los_Angeles".to_string());
+            Ok(Some(user))
+        });
 
     // Setup notifications manager mock
     let nm = MockNotificationsManager::new();
@@ -223,7 +227,8 @@ async fn test_user_menu_section_success() {
         parts.headers.get(CONTENT_TYPE).unwrap(),
         &HeaderValue::from_static("text/html; charset=utf-8"),
     );
-    assert!(!bytes.is_empty());
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.contains(r#"data-user-timezone="America/Los_Angeles""#));
 }
 
 #[tokio::test]

--- a/ocg-server/src/templates/auth.rs
+++ b/ocg-server/src/templates/auth.rs
@@ -102,6 +102,8 @@ pub(crate) struct User {
     pub belongs_to_community_team: Option<bool>,
     /// Display name of the user, if any.
     pub name: Option<String>,
+    /// Preferred timezone for rendering user-localized dates.
+    pub timezone: Option<String>,
     /// Username, if any.
     pub username: Option<String>,
 }
@@ -117,6 +119,7 @@ impl User {
             belongs_to_any_group_team: auth_session_user.and_then(|u| u.belongs_to_any_group_team),
             belongs_to_community_team: auth_session_user.and_then(|u| u.belongs_to_community_team),
             name: auth_session_user.map(|u| u.name.clone()),
+            timezone: auth_session_user.and_then(|u| u.timezone.clone()),
             username: auth_session_user.map(|u| u.username.clone()),
         };
         Ok(user)

--- a/ocg-server/static/js/event/timezone-localization.js
+++ b/ocg-server/static/js/event/timezone-localization.js
@@ -1,0 +1,139 @@
+import { markDatasetReady, setElementHidden } from "/static/js/common/dom.js";
+
+const LOCALIZED_TIME_SELECTOR = "[data-localized-time][data-starts-at][data-event-timezone]";
+const USER_MENU_BUTTON_SELECTOR =
+  '#user-dropdown-button[data-logged-in="true"][data-user-timezone]';
+const LISTENER_READY_KEY = "eventTimezoneLocalizationReady";
+const DEFAULT_PREFIX = "Your time";
+
+const formatterCache = new Map();
+
+const getUserPreferredTimezone = () => {
+  const button = document.querySelector(USER_MENU_BUTTON_SELECTOR);
+  const timezone = button?.dataset?.userTimezone;
+  return typeof timezone === "string" ? timezone.trim() : "";
+};
+
+const parseIsoDate = (value) => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const getDateTimeFormatter = (timeZone) => {
+  if (!formatterCache.has(timeZone)) {
+    formatterCache.set(
+      timeZone,
+      new Intl.DateTimeFormat(undefined, {
+        timeZone,
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZoneName: "short",
+      }),
+    );
+  }
+
+  return formatterCache.get(timeZone);
+};
+
+export const buildLocalizedTimeLabel = ({
+  end,
+  prefix = DEFAULT_PREFIX,
+  start,
+  timezone,
+}) => {
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+    return "";
+  }
+  if (typeof timezone !== "string" || timezone.trim().length === 0) {
+    return "";
+  }
+
+  const formattedStart = getDateTimeFormatter(timezone).format(start);
+  if (!(end instanceof Date) || Number.isNaN(end.getTime())) {
+    return `${prefix}: ${formattedStart}`;
+  }
+
+  const formattedEnd = getDateTimeFormatter(timezone).format(end);
+  return `${prefix}: ${formattedStart} - ${formattedEnd}`;
+};
+
+export const applyUserTimezoneToEventTimes = (root = document) => {
+  const userTimezone = getUserPreferredTimezone();
+  if (!userTimezone) {
+    return 0;
+  }
+
+  let updatedCount = 0;
+  root.querySelectorAll(LOCALIZED_TIME_SELECTOR).forEach((element) => {
+    const eventTimezone = (element.dataset.eventTimezone || "").trim();
+    const startsAt = parseIsoDate(element.dataset.startsAt);
+    const endsAt = parseIsoDate(element.dataset.endsAt);
+    const prefix = (element.dataset.localizedTimePrefix || DEFAULT_PREFIX).trim() || DEFAULT_PREFIX;
+
+    if (!eventTimezone || eventTimezone === userTimezone || !startsAt) {
+      element.textContent = "";
+      setElementHidden(element, true);
+      return;
+    }
+
+    const localizedLabel = buildLocalizedTimeLabel({
+      start: startsAt,
+      end: endsAt,
+      prefix,
+      timezone: userTimezone,
+    });
+    if (!localizedLabel) {
+      element.textContent = "";
+      setElementHidden(element, true);
+      return;
+    }
+
+    element.textContent = `(${localizedLabel})`;
+    setElementHidden(element, false);
+    updatedCount += 1;
+  });
+
+  return updatedCount;
+};
+
+const shouldRefreshTimezoneLabels = (target) => {
+  if (target === document || target === document.body) {
+    return true;
+  }
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return target.matches(USER_MENU_BUTTON_SELECTOR) || Boolean(target.querySelector(USER_MENU_BUTTON_SELECTOR));
+};
+
+const handleAfterSwap = (event) => {
+  const target = event?.detail?.target || event?.target;
+  if (!shouldRefreshTimezoneLabels(target)) {
+    return;
+  }
+
+  applyUserTimezoneToEventTimes();
+};
+
+const initializeTimezoneLocalization = () => {
+  applyUserTimezoneToEventTimes();
+  if (!markDatasetReady(document.documentElement, LISTENER_READY_KEY)) {
+    return;
+  }
+
+  document.addEventListener("htmx:afterSwap", handleAfterSwap);
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeTimezoneLocalization, { once: true });
+} else {
+  initializeTimezoneLocalization();
+}

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -66,6 +66,7 @@
       <button id="user-dropdown-button"
               data-logged-in="true"
               data-profile-complete="{{ user.profile_complete }}"
+              data-user-timezone="{{ user.timezone.as_deref().unwrap_or("") }}"
               class="cursor-pointer group rounded-full bg-white border text-base leading-none border-primary-500 text-primary-700 hover:text-primary-900 hover:border-primary-900 size-[38px] p-0.5 overflow-hidden">
         <div class="font-semibold uppercase mt-px">
           {{ self::user_initials(user.name.as_deref() , user.username.as_deref().unwrap_or("")) }}

--- a/ocg-server/templates/event/page.html
+++ b/ocg-server/templates/event/page.html
@@ -43,6 +43,7 @@
   <script type="module" src="/static/js/event/attendance.js"></script>
   <script type="module" src="/static/js/event/agenda-tabs.js"></script>
   <script type="module" src="/static/js/event/cfs.js"></script>
+  <script type="module" src="/static/js/event/timezone-localization.js"></script>
 {% endblock scripts -%}
 
 {% block content -%}
@@ -246,6 +247,10 @@
                             {{ start_tz.format("%b %e, %G") }}
                           </div>
                           <div class="mt-1 text-sm text-stone-600">{{ start_tz.format("%I:%M %p") }}</div>
+                          <div data-localized-time
+                               data-starts-at="{{ starts_at.to_rfc3339() }}"
+                               data-event-timezone="{{ event.timezone }}"
+                               class="mt-1 text-xs text-stone-500 hidden"></div>
                         </div>
                         <div class="text-stone-400 mt-6 xl:mt-7">→</div>
                         <div>
@@ -257,6 +262,10 @@
                             {{ end_tz.format("%b %e, %G") }}
                           </div>
                           <div class="mt-1 text-sm text-stone-600">{{ end_tz.format("%I:%M %p") }}</div>
+                          <div data-localized-time
+                               data-starts-at="{{ ends_at.to_rfc3339() }}"
+                               data-event-timezone="{{ event.timezone }}"
+                               class="mt-1 text-xs text-stone-500 hidden"></div>
                         </div>
                       </div>
                     {% else -%}
@@ -270,6 +279,11 @@
                       <div class="mt-2 text-base text-stone-600">
                         {{ start_tz.format("%I:%M %p") }} - {{ end_tz.format("%I:%M %p %Z") }}
                       </div>
+                      <div data-localized-time
+                           data-starts-at="{{ starts_at.to_rfc3339() }}"
+                           data-ends-at="{{ ends_at.to_rfc3339() }}"
+                           data-event-timezone="{{ event.timezone }}"
+                           class="mt-1 text-xs text-stone-500 hidden"></div>
                     {% endif -%}
                     {% when None -%}
                     {# Single-day event without end time #}
@@ -280,6 +294,10 @@
                       {{ start_tz.format("%B %e, %G") }}
                     </div>
                     <div class="mt-2 text-base text-stone-600">{{ start_tz.format("%I:%M %p %Z") }}</div>
+                    <div data-localized-time
+                         data-starts-at="{{ starts_at.to_rfc3339() }}"
+                         data-event-timezone="{{ event.timezone }}"
+                         class="mt-1 text-xs text-stone-500 hidden"></div>
                   {% endmatch -%}
                 {% else -%}
                   <div class="text-lg sm:text-xl xl:text-3xl font-semibold text-stone-800">TBD</div>
@@ -741,6 +759,13 @@
         {{ session.starts_at.with_timezone(event.timezone).format("%l:%M %p %Z") }}
       {% endif -%}
     </div>
+    <div data-localized-time
+         data-starts-at="{{ session.starts_at.to_rfc3339() }}"
+         {% if let Some(ends_at) = &session.ends_at -%}
+           data-ends-at="{{ ends_at.to_rfc3339() }}"
+         {% endif -%}
+         data-event-timezone="{{ event.timezone }}"
+         class="mb-2 text-xs text-stone-500 hidden"></div>
     <div class="flex flex-col sm:flex-row items-start gap-2">
       <h3 class="md:text-lg font-semibold text-stone-900">{{ session.name|demoji }}</h3>
       {{ badges::event_badge(kind = session.kind, extra_styles = Some("mt-1 md:mt-1.5") ) -}}

--- a/tests/unit/event/timezone-localization.test.js
+++ b/tests/unit/event/timezone-localization.test.js
@@ -1,0 +1,71 @@
+import { expect } from "@open-wc/testing";
+
+import {
+  applyUserTimezoneToEventTimes,
+  buildLocalizedTimeLabel,
+} from "/static/js/event/timezone-localization.js";
+import { resetDom } from "/tests/unit/test-utils/dom.js";
+
+describe("event timezone localization", () => {
+  afterEach(() => {
+    resetDom();
+  });
+
+  it("renders a localized label when user and event timezones differ", () => {
+    document.body.innerHTML = `
+      <button
+        id="user-dropdown-button"
+        data-logged-in="true"
+        data-user-timezone="America/Los_Angeles"
+      ></button>
+      <div
+        data-localized-time
+        data-starts-at="2030-07-14T23:00:00Z"
+        data-ends-at="2030-07-15T00:00:00Z"
+        data-event-timezone="America/New_York"
+        class="hidden"
+      ></div>
+    `;
+
+    const updated = applyUserTimezoneToEventTimes();
+    const localized = document.querySelector("[data-localized-time]");
+
+    expect(updated).to.equal(1);
+    expect(localized.classList.contains("hidden")).to.equal(false);
+    expect(localized.textContent).to.match(/^\(Your time:/);
+  });
+
+  it("keeps labels hidden when the user timezone matches the event timezone", () => {
+    document.body.innerHTML = `
+      <button
+        id="user-dropdown-button"
+        data-logged-in="true"
+        data-user-timezone="UTC"
+      ></button>
+      <div
+        data-localized-time
+        data-starts-at="2030-07-14T23:00:00Z"
+        data-event-timezone="UTC"
+        class="hidden"
+      >old</div>
+    `;
+
+    const updated = applyUserTimezoneToEventTimes();
+    const localized = document.querySelector("[data-localized-time]");
+
+    expect(updated).to.equal(0);
+    expect(localized.classList.contains("hidden")).to.equal(true);
+    expect(localized.textContent).to.equal("");
+  });
+
+  it("builds a single-time label when no end time is provided", () => {
+    const start = new Date("2030-07-14T23:00:00Z");
+    const label = buildLocalizedTimeLabel({
+      start,
+      timezone: "America/Los_Angeles",
+    });
+
+    expect(label.startsWith("Your time: ")).to.equal(true);
+    expect(label.includes(" - ")).to.equal(false);
+  });
+});


### PR DESCRIPTION
helps with #582 

Why
Public event pages currently show times only in the event timezone, which makes it harder for logged-in users in other regions to quickly understand when meetings happen for them.

What changed
This adds a client-side localization layer on event pages that preserves cacheable server-rendered HTML while showing an additional (Your time: ...) label for logged-in users whose preferred timezone differs from the event timezone.

Implementation details
Expose the logged-in user's timezone in the user menu markup (data-user-timezone) by wiring timezone through the template User model.
Add hidden data-localized-time anchors next to event and session time displays in event/page.html with canonical timestamp + event timezone metadata.
Add a new module, static/js/event/timezone-localization.js, that:
Reads user timezone from the HTMX-loaded user menu.
Formats localized labels with Intl.DateTimeFormat.
Skips labels when user timezone matches event timezone.
Re-applies localization after HTMX swaps.
Add unit coverage for the localization module and update auth handler template rendering test assertions for timezone data attributes.
Notes for reviewers
The event page response remains shared-cache friendly; personalization is intentionally done only in browser-side enhancement code.

Testing
Added JS unit tests for label building and timezone-application behavior.
Updated Rust auth handler test for user menu timezone attribute.