### PR TITLE
Add Credentials tab for external badge issuance

### DIFF
--- a/ocg-server/src/config.rs
+++ b/ocg-server/src/config.rs
@@ -42,6 +42,8 @@ pub(crate) struct Config {
     /// HTTP server configuration.
     pub server: HttpServerConfig,
 
+    /// Optional CertDirectory credentials integration settings.
+    pub credentials: Option<CredentialsConfig>,
     /// Meetings configuration.
     pub meetings: Option<MeetingsConfig>,
     /// Payments configuration.
@@ -101,10 +103,23 @@ impl fmt::Debug for Config {
             .field("images", &self.images)
             .field("log", &self.log)
             .field("server", &self.server)
+            .field("credentials", &self.credentials)
             .field("meetings", &self.meetings)
             .field("payments", &self.payments)
             .finish()
     }
+}
+
+/// Optional CertDirectory credentials integration configuration.
+///
+/// When absent, the server uses the production CertDirectory origin
+/// (`https://credentials.certdirectory.io`). For local development against the
+/// staging API, set `base_url` to `https://dev.credentials.certdirectory.io`.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub(crate) struct CredentialsConfig {
+    /// CertDirectory origin (no trailing path). Example:
+    /// `https://dev.credentials.certdirectory.io`.
+    pub base_url: String,
 }
 
 /// Email configuration.
@@ -583,6 +598,7 @@ mod tests {
                 cookie: None,
                 redirect_hosts: None,
             },
+            credentials: None,
             meetings: Some(MeetingsConfig {
                 zoom: Some(MeetingsZoomConfig {
                     account_id: "zoom-account-id".to_string(),

--- a/ocg-server/src/handlers/dashboard/group.rs
+++ b/ocg-server/src/handlers/dashboard/group.rs
@@ -23,6 +23,7 @@ mod tests;
 
 pub(crate) mod analytics;
 pub(crate) mod attendees;
+pub(crate) mod credentials;
 pub(crate) mod events;
 pub(crate) mod home;
 pub(crate) mod invitation_requests;

--- a/ocg-server/src/handlers/dashboard/group/credentials.rs
+++ b/ocg-server/src/handlers/dashboard/group/credentials.rs
@@ -1,0 +1,329 @@
+//! HTTP handlers for the Credentials section in the group dashboard.
+//!
+//! Stateless CertDirectory integration: organizers supply an API key + badge ID
+//! from the browser (localStorage). The server resolves attendee emails and
+//! calls CertDirectory; emails never reach the browser.
+
+use std::collections::HashMap;
+
+use askama::Template;
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{Html, IntoResponse},
+};
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedCommunityId, SelectedGroupId},
+    },
+    services::credentials::{CredentialsClient, CredentialsError, friendly},
+    templates::dashboard::group::{
+        attendees::{Attendee, AttendeesFilters},
+        credentials,
+    },
+    types::{event::EventSummary, permissions::GroupPermission},
+};
+
+/// Header carrying the CertDirectory API key (from browser localStorage).
+const HEADER_API_KEY: &str = "x-cd-api-key";
+/// Header carrying the CertDirectory badge / achievement UUID.
+const HEADER_BADGE_ID: &str = "x-cd-badge-id";
+
+/// Displays the Credentials tab for a specific event.
+#[instrument(skip_all, err)]
+pub(crate) async fn tab_page(
+    CurrentUser(user): CurrentUser,
+    SelectedCommunityId(community_id): SelectedCommunityId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(event_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let filters = AttendeesFilters::default();
+    let (can_manage_events, event, search_attendees_results) = tokio::try_join!(
+        db.user_has_group_permission(
+            &community_id,
+            &group_id,
+            &user.user_id,
+            GroupPermission::EventsWrite
+        ),
+        db.get_event_summary(community_id, group_id, event_id),
+        // Default filters → LIMIT NULL → all attendees (needed for status matching).
+        db.search_event_attendees(group_id, event_id, &filters)
+    )?;
+
+    let template = credentials::ListPage {
+        attendees: search_attendees_results.attendees,
+        can_manage_events,
+        event,
+        group_id,
+        total: search_attendees_results.total,
+    };
+
+    Ok(Html(template.render()?))
+}
+
+/// Validate API key + badge ID against CertDirectory and return the badge name.
+#[instrument(skip_all, err)]
+pub(crate) async fn validate(
+    SelectedCommunityId(community_id): SelectedCommunityId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    State(cred): State<CredentialsClient>,
+    Path(event_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, HandlerError> {
+    let _: EventSummary = db.get_event_summary(community_id, group_id, event_id).await?;
+
+    let (api_key, badge_id) = match read_cred_headers(&headers) {
+        Ok(v) => v,
+        Err(msg) => return Ok((StatusCode::BAD_REQUEST, msg).into_response()),
+    };
+
+    match cred.get_badge(&api_key, &badge_id).await {
+        Ok(badge) => Ok(Json(ValidateRow {
+            badge_id: badge.id,
+            badge_name: badge.name,
+            is_active: badge.is_active,
+        })
+        .into_response()),
+        Err(e) => Ok((StatusCode::BAD_GATEWAY, friendly(&e)).into_response()),
+    }
+}
+
+/// Derive live issuance status for each attendee (matched by email server-side).
+///
+/// Response contains `user_id` + status only — never emails.
+#[instrument(skip_all, err)]
+pub(crate) async fn status(
+    SelectedCommunityId(community_id): SelectedCommunityId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    State(cred): State<CredentialsClient>,
+    Path(event_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, HandlerError> {
+    // Ensure the event belongs to the selected group (permission is enforced by
+    // the EventsWrite route layer).
+    let _: EventSummary = db.get_event_summary(community_id, group_id, event_id).await?;
+
+    let (api_key, badge_id) = match read_cred_headers(&headers) {
+        Ok(v) => v,
+        Err(msg) => return Ok((StatusCode::BAD_REQUEST, msg).into_response()),
+    };
+
+    let filters = AttendeesFilters::default();
+    let attendees = db
+        .search_event_attendees(group_id, event_id, &filters)
+        .await?;
+
+    let issued = match cred.list_by_badge(&api_key, &badge_id).await {
+        Ok(list) => list,
+        Err(e) => {
+            return Ok((StatusCode::BAD_GATEWAY, friendly(&e)).into_response());
+        }
+    };
+
+    let by_email: HashMap<String, &crate::services::credentials::ListedCredential> = issued
+        .iter()
+        .map(|c| (c.email.to_lowercase(), c))
+        .collect();
+
+    let rows: Vec<StatusRow> = attendees
+        .attendees
+        .iter()
+        .map(|a| {
+            let match_cred = by_email.get(&a.email.to_lowercase());
+            StatusRow {
+                user_id: a.user.user_id,
+                status: match_cred
+                    .map(|c| map_cd_status(&c.status))
+                    .unwrap_or_else(|| "not_issued".to_string()),
+                eligible: a.can_receive_attendee_email,
+                verify_url: match_cred.map(|c| c.verify_url.clone()),
+                credential_id: match_cred.map(|c| c.credential_id.clone()),
+            }
+        })
+        .collect();
+
+    Ok(Json(rows).into_response())
+}
+
+/// Issue a credential to a single attendee.
+#[instrument(skip_all, err)]
+pub(crate) async fn issue_one(
+    SelectedCommunityId(community_id): SelectedCommunityId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    State(cred): State<CredentialsClient>,
+    Path((event_id, user_id)): Path<(Uuid, Uuid)>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, HandlerError> {
+    let _: EventSummary = db.get_event_summary(community_id, group_id, event_id).await?;
+
+    let (api_key, badge_id) = match read_cred_headers(&headers) {
+        Ok(v) => v,
+        Err(msg) => return Ok((StatusCode::BAD_REQUEST, msg).into_response()),
+    };
+
+    let filters = AttendeesFilters::default();
+    let attendees = db
+        .search_event_attendees(group_id, event_id, &filters)
+        .await?;
+    let Some(attendee) = attendees
+        .attendees
+        .into_iter()
+        .find(|a| a.user.user_id == user_id)
+    else {
+        return Ok((StatusCode::NOT_FOUND, "attendee not found").into_response());
+    };
+
+    if !attendee.can_receive_attendee_email {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            "attendee is not eligible to receive credentials (email opt-in / verification)",
+        )
+            .into_response());
+    }
+
+    // No re-issue (locked decision): if any credential already exists for this
+    // email+badge, treat as already issued and do not call the issue API.
+    match cred.list_by_badge(&api_key, &badge_id).await {
+        Ok(list) => {
+            let email_lc = attendee.email.to_lowercase();
+            if let Some(existing) = list.iter().find(|c| c.email == email_lc) {
+                return Ok(Json(IssueRow {
+                    user_id,
+                    status: map_cd_status(&existing.status),
+                    verify_url: Some(existing.verify_url.clone()),
+                    credential_id: Some(existing.credential_id.clone()),
+                    error: None,
+                })
+                .into_response());
+            }
+        }
+        Err(e) => {
+            return Ok((StatusCode::BAD_GATEWAY, friendly(&e)).into_response());
+        }
+    }
+
+    let name = display_name(&attendee);
+    match cred
+        .issue(&api_key, &badge_id, &name, &attendee.email)
+        .await
+    {
+        Ok(r) => Ok(Json(IssueRow {
+            user_id,
+            status: map_cd_status(&r.status),
+            verify_url: Some(r.verify_url),
+            credential_id: Some(r.credential_id),
+            error: None,
+        })
+        .into_response()),
+        Err(CredentialsError::Duplicate) => Ok(Json(IssueRow {
+            user_id,
+            status: "issued".to_string(),
+            verify_url: None,
+            credential_id: None,
+            error: None,
+        })
+        .into_response()),
+        Err(e) => Ok(Json(IssueRow {
+            user_id,
+            status: "failed".to_string(),
+            verify_url: None,
+            credential_id: None,
+            error: Some(friendly(&e)),
+        })
+        .into_response()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn read_cred_headers(headers: &HeaderMap) -> Result<(String, String), &'static str> {
+    let api_key = headers
+        .get(HEADER_API_KEY)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or("missing X-CD-Api-Key header")?;
+    let badge_id = headers
+        .get(HEADER_BADGE_ID)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or("missing X-CD-Badge-Id header")?;
+    Ok((api_key.to_string(), badge_id.to_string()))
+}
+
+fn display_name(attendee: &Attendee) -> String {
+    attendee
+        .user
+        .name
+        .as_deref()
+        .filter(|n| !n.trim().is_empty())
+        .unwrap_or(attendee.user.username.as_str())
+        .to_string()
+}
+
+/// Map CertDirectory status strings into the dashboard vocabulary.
+///
+/// Any known CD status counts as "already has a credential" for the UI
+/// (button disabled). Unknown values fall through as-is.
+fn map_cd_status(cd: &str) -> String {
+    match cd {
+        "valid" | "pending" => {
+            // pending = issued, awaiting claim — still "issued" for the button.
+            if cd == "pending" {
+                "pending".to_string()
+            } else {
+                "issued".to_string()
+            }
+        }
+        "expired" => "expired".to_string(),
+        "revoked" => "revoked".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Per-attendee status row returned to the browser (no emails).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StatusRow {
+    pub user_id: Uuid,
+    pub status: String,
+    pub eligible: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
+}
+
+/// Result of validating API key + badge ID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ValidateRow {
+    pub badge_id: String,
+    pub badge_name: String,
+    pub is_active: bool,
+}
+
+/// Result of a single-attendee issue call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IssueRow {
+    pub user_id: Uuid,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -1456,6 +1456,7 @@ pub(crate) fn test_state_with_server_cfg(
 ) -> router::State {
     router::State {
         activity_tracker: Arc::new(crate::activity_tracker::MockActivityTracker::new()),
+        credentials_client: crate::services::credentials::CredentialsClient::production(),
         db,
         image_storage,
         meetings_cfg: None,
@@ -1509,6 +1510,7 @@ impl TestRouterBuilder {
             activity_tracker,
             db,
             is,
+            crate::services::credentials::CredentialsClient::production(),
             self.meetings_cfg,
             self.payments_cfg,
             payments_manager,

--- a/ocg-server/src/main.rs
+++ b/ocg-server/src/main.rs
@@ -117,10 +117,19 @@ async fn main() -> Result<()> {
     );
 
     // Serve HTTP requests until a shutdown signal is received
+    let credentials_client = match cfg.credentials.as_ref() {
+        Some(c) => services::credentials::CredentialsClient::new(c.base_url.clone()),
+        None => services::credentials::CredentialsClient::production(),
+    };
+    info!(
+        credentials_base_url = %credentials_client.base_url(),
+        "credentials client configured"
+    );
     run_server(
         activity_tracker,
         db,
         image_storage,
+        credentials_client,
         cfg.meetings.clone(),
         cfg.payments.clone(),
         payments_manager,
@@ -141,6 +150,7 @@ async fn run_server(
     activity_tracker: Arc<ActivityTrackerDB>,
     db: Arc<PgDB>,
     image_storage: DynImageStorage,
+    credentials_client: services::credentials::CredentialsClient,
     meetings_cfg: Option<MeetingsConfig>,
     payments_cfg: Option<PaymentsConfig>,
     payments_manager: DynPaymentsManager,
@@ -152,6 +162,7 @@ async fn run_server(
         activity_tracker,
         db,
         image_storage,
+        credentials_client,
         meetings_cfg,
         payments_cfg,
         payments_manager,

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -37,8 +37,8 @@ use crate::{
         community, event, group, images, meetings, payments, site,
     },
     services::{
-        images::DynImageStorage, notifications::DynNotificationsManager,
-        payments::DynPaymentsManager,
+        credentials::CredentialsClient, images::DynImageStorage,
+        notifications::DynNotificationsManager, payments::DynPaymentsManager,
     },
 };
 
@@ -106,6 +106,8 @@ struct StaticFile;
 pub(crate) struct State {
     /// Activity tracker handle.
     pub activity_tracker: DynActivityTracker,
+    /// CertDirectory credentials HTTP client.
+    pub credentials_client: CredentialsClient,
     /// Database handle.
     pub db: DynDB,
     /// Image storage provider handle.
@@ -135,6 +137,7 @@ pub(crate) async fn setup(
     activity_tracker: DynActivityTracker,
     db: DynDB,
     image_storage: DynImageStorage,
+    credentials_client: CredentialsClient,
     meetings_cfg: Option<MeetingsConfig>,
     payments_cfg: Option<PaymentsConfig>,
     payments_manager: DynPaymentsManager,
@@ -154,6 +157,7 @@ pub(crate) async fn setup(
     let state = State {
         db: db.clone(),
         activity_tracker,
+        credentials_client,
         image_storage,
         meetings_cfg,
         notifications_manager,

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -255,6 +255,10 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             "/events/{event_id}/waitlist",
             get(dashboard::group::waitlist::list_page),
         )
+        .route(
+            "/events/{event_id}/credentials",
+            get(dashboard::group::credentials::tab_page),
+        )
         .route("/logs", get(dashboard::group::logs::list_page))
         .route("/members", get(dashboard::group::members::list_page))
         .route(
@@ -285,6 +289,18 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
         .route(
             "/events/{event_id}/attendees/{user_id}/check-in",
             post(dashboard::group::attendees::manual_check_in),
+        )
+        .route(
+            "/events/{event_id}/attendees/{user_id}/credentials/issue",
+            post(dashboard::group::credentials::issue_one),
+        )
+        .route(
+            "/events/{event_id}/credentials/status",
+            post(dashboard::group::credentials::status),
+        )
+        .route(
+            "/events/{event_id}/credentials/validate",
+            post(dashboard::group::credentials::validate),
         )
         .route(
             "/events/{event_id}/attendees/{user_id}/invitation/cancel",

--- a/ocg-server/src/services.rs
+++ b/ocg-server/src/services.rs
@@ -1,5 +1,8 @@
 //! Services modules.
 
+/// External credentials issuer (CertDirectory) client.
+pub(crate) mod credentials;
+
 /// Images service module.
 pub(crate) mod images;
 

--- a/ocg-server/src/services/credentials/client.rs
+++ b/ocg-server/src/services/credentials/client.rs
@@ -1,0 +1,399 @@
+//! HTTP client for the CertDirectory credentials API (v1).
+//!
+//! Used by the OCG dashboard to issue badges to event attendees without
+//! exposing attendee emails to the browser. The organizer's API key is
+//! supplied per-request (from browser localStorage) and never stored in OCG.
+
+use std::time::Duration;
+
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use tracing::{instrument, warn};
+use uuid::Uuid;
+
+/// Default CertDirectory production API origin (no trailing slash).
+pub(crate) const DEFAULT_BASE_URL: &str = "https://credentials.certdirectory.io";
+
+/// Timeout for outbound CertDirectory API calls.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Page size when listing credentials by badge.
+const LIST_PAGE_SIZE: u32 = 100;
+
+/// CertDirectory credentials HTTP client.
+#[derive(Clone)]
+pub(crate) struct CredentialsClient {
+    /// CertDirectory origin, e.g. `https://credentials.certdirectory.io`.
+    base_url: String,
+    /// Shared HTTP client.
+    http: HttpClient,
+}
+
+/// Errors returned by the credentials client.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CredentialsError {
+    /// Network / transport failure.
+    #[error("network: {0}")]
+    Network(String),
+    /// Invalid or missing API key (401).
+    #[error("unauthorized")]
+    Unauthorized,
+    /// Org not approved / no signing keys / forbidden (403).
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+    /// Monthly recipient quota reached.
+    #[error("quota reached")]
+    QuotaReached,
+    /// Attendee already has an active non-expiring credential for this badge.
+    #[error("duplicate (already active)")]
+    Duplicate,
+    /// Rate limited (429).
+    #[error("rate limited")]
+    RateLimited,
+    /// Other client / validation error (400).
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    /// Badge or resource not found (404).
+    #[error("not found")]
+    NotFound,
+    /// Unexpected response.
+    #[error("unexpected: {0}")]
+    Unexpected(String),
+}
+
+/// Successful issue result.
+#[derive(Debug, Clone)]
+pub(crate) struct IssueResult {
+    /// Public credential identifier (e.g. `CRD-…`).
+    pub credential_id: String,
+    /// Public verify URL.
+    pub verify_url: String,
+    /// Credential status (`pending`, etc.).
+    pub status: String,
+}
+
+/// One credential from a list response (email + status only — used server-side).
+#[derive(Debug, Clone)]
+pub(crate) struct ListedCredential {
+    /// Recipient email (lowercased by CertDirectory).
+    pub email: String,
+    /// Credential status (`pending` / `valid` / `expired` / `revoked`).
+    pub status: String,
+    /// Public credential identifier.
+    pub credential_id: String,
+    /// Public verify URL.
+    pub verify_url: String,
+}
+
+/// Badge details returned by `GET /api/v1/badges/:badgeId`.
+#[derive(Debug, Clone)]
+pub(crate) struct BadgeInfo {
+    /// Badge / achievement UUID.
+    pub id: String,
+    /// Human-readable badge name.
+    pub name: String,
+    /// Whether the badge template is active.
+    pub is_active: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct IssueBody<'a> {
+    #[serde(rename = "badgeId")]
+    badge_id: &'a str,
+    recipient: IssueRecipient<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct IssueRecipient<'a> {
+    name: &'a str,
+    email: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct IssueResponse {
+    credential: IssueCredentialBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct IssueCredentialBody {
+    #[serde(rename = "credentialId")]
+    credential_id: String,
+    status: String,
+    #[serde(rename = "verifyUrl")]
+    verify_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListResponse {
+    credentials: Vec<ListCredentialBody>,
+    pagination: ListPagination,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListCredentialBody {
+    #[serde(rename = "credentialId")]
+    credential_id: String,
+    status: String,
+    recipient: ListRecipient,
+    #[serde(rename = "verifyUrl")]
+    verify_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListRecipient {
+    email: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListPagination {
+    #[serde(rename = "hasMore")]
+    has_more: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct BadgeResponse {
+    badge: BadgeBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct BadgeBody {
+    id: String,
+    name: String,
+    #[serde(rename = "isActive", default)]
+    is_active: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorBody {
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+impl CredentialsClient {
+    /// Create a client pointed at `base_url` (trailing slash is stripped).
+    pub(crate) fn new(base_url: impl Into<String>) -> Self {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        let http = HttpClient::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .expect("failed to build credentials http client");
+        Self { base_url, http }
+    }
+
+    /// Create a client using the production CertDirectory origin.
+    pub(crate) fn production() -> Self {
+        Self::new(DEFAULT_BASE_URL)
+    }
+
+    /// Returns the configured CertDirectory origin (no trailing slash).
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Fetch a badge by ID (validates API key + badge ownership).
+    #[instrument(skip(self, api_key), err)]
+    pub(crate) async fn get_badge(
+        &self,
+        api_key: &str,
+        badge_id: &str,
+    ) -> Result<BadgeInfo, CredentialsError> {
+        Uuid::parse_str(badge_id).map_err(|_| {
+            CredentialsError::BadRequest("badge ID must be a valid UUID".to_string())
+        })?;
+
+        let url = format!("{}/api/v1/badges/{badge_id}", self.base_url);
+        let response = self
+            .http
+            .get(&url)
+            .bearer_auth(api_key)
+            .send()
+            .await
+            .map_err(|e| CredentialsError::Network(e.to_string()))?;
+
+        let status = response.status();
+        if status.is_success() {
+            let parsed: BadgeResponse = response
+                .json()
+                .await
+                .map_err(|e| CredentialsError::Network(e.to_string()))?;
+            return Ok(BadgeInfo {
+                id: parsed.badge.id,
+                name: parsed.badge.name,
+                is_active: parsed.badge.is_active,
+            });
+        }
+
+        Err(Self::map_error(status, response).await)
+    }
+
+    /// Issue one credential to `email` for `badge_id`.
+    #[instrument(skip(self, api_key, name, email), err)]
+    pub(crate) async fn issue(
+        &self,
+        api_key: &str,
+        badge_id: &str,
+        name: &str,
+        email: &str,
+    ) -> Result<IssueResult, CredentialsError> {
+        let url = format!("{}/api/v1/credentials", self.base_url);
+        let body = IssueBody {
+            badge_id,
+            recipient: IssueRecipient { name, email },
+        };
+
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CredentialsError::Network(e.to_string()))?;
+
+        let status = response.status();
+        if status.as_u16() == 201 {
+            let parsed: IssueResponse = response
+                .json()
+                .await
+                .map_err(|e| CredentialsError::Network(e.to_string()))?;
+            return Ok(IssueResult {
+                credential_id: parsed.credential.credential_id,
+                verify_url: parsed.credential.verify_url,
+                status: parsed.credential.status,
+            });
+        }
+
+        Err(Self::map_error(status, response).await)
+    }
+
+    /// List all credentials for a badge (paginated until exhausted).
+    #[instrument(skip(self, api_key), err)]
+    pub(crate) async fn list_by_badge(
+        &self,
+        api_key: &str,
+        badge_id: &str,
+    ) -> Result<Vec<ListedCredential>, CredentialsError> {
+        // Validate badge_id early so we don't hit the API with garbage.
+        Uuid::parse_str(badge_id).map_err(|_| {
+            CredentialsError::BadRequest("badge ID must be a valid UUID".to_string())
+        })?;
+
+        let mut out = Vec::new();
+        let mut offset: u32 = 0;
+
+        loop {
+            let url = format!(
+                "{}/api/v1/credentials?badgeId={badge_id}&limit={LIST_PAGE_SIZE}&offset={offset}",
+                self.base_url
+            );
+            let response = self
+                .http
+                .get(&url)
+                .bearer_auth(api_key)
+                .send()
+                .await
+                .map_err(|e| CredentialsError::Network(e.to_string()))?;
+
+            let status = response.status();
+            if !status.is_success() {
+                return Err(Self::map_error(status, response).await);
+            }
+
+            let parsed: ListResponse = response
+                .json()
+                .await
+                .map_err(|e| CredentialsError::Network(e.to_string()))?;
+
+            for c in parsed.credentials {
+                out.push(ListedCredential {
+                    email: c.recipient.email.to_lowercase(),
+                    status: c.status,
+                    credential_id: c.credential_id,
+                    verify_url: c.verify_url,
+                });
+            }
+
+            if !parsed.pagination.has_more {
+                break;
+            }
+            offset = offset.saturating_add(LIST_PAGE_SIZE);
+        }
+
+        Ok(out)
+    }
+
+    /// Map a non-success HTTP response into a typed error.
+    async fn map_error(
+        status: reqwest::StatusCode,
+        response: reqwest::Response,
+    ) -> CredentialsError {
+        let body_text = response.text().await.unwrap_or_default();
+        let message = serde_json::from_str::<ErrorBody>(&body_text)
+            .ok()
+            .and_then(|b| b.message.or(b.error))
+            .unwrap_or_else(|| body_text.clone());
+
+        match status.as_u16() {
+            401 => CredentialsError::Unauthorized,
+            403 => CredentialsError::Forbidden(message),
+            404 => CredentialsError::NotFound,
+            429 => CredentialsError::RateLimited,
+            400 | 409 => {
+                let lower = message.to_lowercase();
+                if lower.contains("monthly recipient limit") || lower.contains("limit reached") {
+                    CredentialsError::QuotaReached
+                } else if lower.contains("already")
+                    || lower.contains("duplicate")
+                    || lower.contains("active")
+                {
+                    CredentialsError::Duplicate
+                } else {
+                    CredentialsError::BadRequest(message)
+                }
+            }
+            code if (500..600).contains(&code) => {
+                warn!(%status, %message, "credentials api server error");
+                CredentialsError::Unexpected(format!("server error ({status}): {message}"))
+            }
+            _ => CredentialsError::Unexpected(format!("unexpected status {status}: {message}")),
+        }
+    }
+}
+
+/// Organizer-facing message for a credentials error (never includes emails/keys).
+pub(crate) fn friendly(err: &CredentialsError) -> String {
+    match err {
+        CredentialsError::Unauthorized => {
+            "Invalid API key — check the key in setup".to_string()
+        }
+        CredentialsError::Forbidden(msg) => {
+            if msg.is_empty() {
+                "Your CertDirectory organization isn't approved or has no signing keys".to_string()
+            } else {
+                format!("Forbidden: {msg}")
+            }
+        }
+        CredentialsError::QuotaReached => {
+            "Monthly recipient limit reached on CertDirectory".to_string()
+        }
+        CredentialsError::Duplicate => "Already issued".to_string(),
+        CredentialsError::RateLimited => {
+            "CertDirectory rate limit hit — try again in a moment".to_string()
+        }
+        CredentialsError::BadRequest(msg) => {
+            if msg.is_empty() {
+                "Bad request to CertDirectory".to_string()
+            } else {
+                msg.clone()
+            }
+        }
+        CredentialsError::NotFound => {
+            "Badge not found for this API key's organization".to_string()
+        }
+        CredentialsError::Network(_) | CredentialsError::Unexpected(_) => {
+            "Couldn't reach CertDirectory — try again".to_string()
+        }
+    }
+}

--- a/ocg-server/src/services/credentials/mod.rs
+++ b/ocg-server/src/services/credentials/mod.rs
@@ -1,0 +1,5 @@
+//! External credentials issuer client (CertDirectory adapter).
+
+pub(crate) mod client;
+
+pub(crate) use client::{CredentialsClient, CredentialsError, ListedCredential, friendly};

--- a/ocg-server/src/templates/dashboard/group.rs
+++ b/ocg-server/src/templates/dashboard/group.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) mod analytics;
 pub(crate) mod attendees;
+pub(crate) mod credentials;
 pub(crate) mod events;
 pub(crate) mod home;
 pub(crate) mod invitation_requests;

--- a/ocg-server/src/templates/dashboard/group/credentials.rs
+++ b/ocg-server/src/templates/dashboard/group/credentials.rs
@@ -1,0 +1,28 @@
+//! Templates for the Credentials tab in the group dashboard.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    templates::helpers::user_initials,
+    types::event::EventSummary,
+};
+
+use super::attendees::Attendee;
+
+/// Credentials tab page for a group's event.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/group/credentials_list.html")]
+pub(crate) struct ListPage {
+    /// Attendees for the selected event (status filled in by JS).
+    pub attendees: Vec<Attendee>,
+    /// Whether the current user can manage events (issue credentials).
+    pub can_manage_events: bool,
+    /// Event for which credentials are managed.
+    pub event: EventSummary,
+    /// Selected group id (used as the localStorage key for the API key).
+    pub group_id: Uuid,
+    /// Total number of attendees.
+    pub total: usize,
+}

--- a/ocg-server/static/js/dashboard/group/credentials.js
+++ b/ocg-server/static/js/dashboard/group/credentials.js
@@ -1,0 +1,488 @@
+/**
+ * Credentials tab — CertDirectory integration (stateless / Phase 1).
+ *
+ * Config (API key per group, badge ID per event) lives in localStorage.
+ * Status and issue calls go through the OCG server with X-CD-* headers so
+ * attendee emails never reach the browser.
+ */
+
+import {
+  confirmAction,
+  showErrorAlert,
+  showSuccessAlert,
+} from "/static/js/common/alerts.js";
+import {
+  initializeMatchingRoots,
+  initializeOnReadyAndHtmxLoad,
+  markDatasetReady,
+} from "/static/js/common/dom.js";
+import { ocgFetch } from "/static/js/common/fetch.js";
+
+const ROOT_SELECTOR = "[data-credentials-root]";
+const READY_KEY = "credentialsReady";
+
+const apiKeyStorageKey = (groupId) => `cd_api_key:${groupId}`;
+const badgeIdStorageKey = (eventId) => `cd_badge_id:${eventId}`;
+const badgeNameStorageKey = (eventId) => `cd_badge_name:${eventId}`;
+
+const STATUS_LABELS = {
+  not_issued: { text: "Not issued", className: "bg-stone-100 text-stone-600" },
+  pending: { text: "Pending", className: "bg-amber-100 text-amber-800" },
+  issued: { text: "Issued", className: "bg-emerald-100 text-emerald-800" },
+  expired: { text: "Expired", className: "bg-stone-200 text-stone-700" },
+  revoked: { text: "Revoked", className: "bg-red-100 text-red-800" },
+  failed: { text: "Failed", className: "bg-red-100 text-red-800" },
+};
+
+/** True when any credential already exists — Issue must stay disabled. */
+const isAlreadyIssued = (status) =>
+  status === "issued" ||
+  status === "pending" ||
+  status === "expired" ||
+  status === "revoked";
+
+const escapeHtml = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+const readConfig = (root) => {
+  const groupId = root.dataset.groupId;
+  const eventId = root.dataset.eventId;
+  return {
+    apiKey: localStorage.getItem(apiKeyStorageKey(groupId)) || "",
+    badgeId: localStorage.getItem(badgeIdStorageKey(eventId)) || "",
+    badgeName: localStorage.getItem(badgeNameStorageKey(eventId)) || "",
+  };
+};
+
+const writeConfig = (root, apiKey, badgeId, badgeName = "") => {
+  const groupId = root.dataset.groupId;
+  const eventId = root.dataset.eventId;
+  if (apiKey) {
+    localStorage.setItem(apiKeyStorageKey(groupId), apiKey);
+  } else {
+    localStorage.removeItem(apiKeyStorageKey(groupId));
+  }
+  if (badgeId) {
+    localStorage.setItem(badgeIdStorageKey(eventId), badgeId);
+  } else {
+    localStorage.removeItem(badgeIdStorageKey(eventId));
+  }
+  if (badgeName) {
+    localStorage.setItem(badgeNameStorageKey(eventId), badgeName);
+  } else {
+    localStorage.removeItem(badgeNameStorageKey(eventId));
+  }
+};
+
+const paintBadgeSummary = (root, badgeName) => {
+  const summary = root.querySelector("[data-credentials-badge-summary]");
+  const nameEl = root.querySelector("[data-credentials-badge-name]");
+  if (!summary || !nameEl) return;
+  if (badgeName) {
+    nameEl.textContent = badgeName;
+    summary.classList.remove("hidden");
+  } else {
+    nameEl.textContent = "";
+    summary.classList.add("hidden");
+  }
+};
+
+/** Hide the badge summary when the inputs no longer match the last saved pair. */
+const syncBadgeSummaryVisibility = (root) => {
+  const saved = readConfig(root);
+  const { apiKey, badgeId } = readInputValues(root);
+  if (saved.apiKey && saved.badgeId && saved.badgeName && apiKey === saved.apiKey && badgeId === saved.badgeId) {
+    paintBadgeSummary(root, saved.badgeName);
+  } else {
+    paintBadgeSummary(root, "");
+  }
+};
+
+const cdHeaders = (apiKey, badgeId) => ({
+  "X-CD-Api-Key": apiKey,
+  "X-CD-Badge-Id": badgeId,
+});
+
+const readInputValues = (root) => {
+  const apiKey = (root.querySelector("[data-credentials-api-key]")?.value || "").trim();
+  const badgeId = (root.querySelector("[data-credentials-badge-id]")?.value || "").trim();
+  return { apiKey, badgeId };
+};
+
+const syncSaveButton = (root) => {
+  const saveBtn = root.querySelector("[data-credentials-save]");
+  if (!saveBtn) return;
+  const { apiKey, badgeId } = readInputValues(root);
+  const ready = Boolean(apiKey && badgeId);
+  saveBtn.disabled = !ready;
+  saveBtn.title = ready
+    ? "Validate with CertDirectory and save"
+    : "Enter both API key and badge ID";
+};
+
+const paintStatus = (row, status, verifyUrl) => {
+  const pill = row.querySelector("[data-credentials-status]");
+  const verify = row.querySelector("[data-credentials-verify]");
+  const issueBtn = row.querySelector("[data-credentials-issue]");
+  const meta = STATUS_LABELS[status] || {
+    text: status || "—",
+    className: "bg-stone-100 text-stone-600",
+  };
+
+  if (pill) {
+    pill.textContent = meta.text;
+    pill.className = `inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${meta.className}`;
+  }
+
+  if (verify) {
+    if (verifyUrl) {
+      verify.href = verifyUrl;
+      verify.classList.remove("hidden");
+    } else {
+      verify.classList.add("hidden");
+      verify.removeAttribute("href");
+    }
+  }
+
+  if (issueBtn) {
+    const eligible = row.dataset.eligible === "true";
+    if (!eligible || isAlreadyIssued(status)) {
+      issueBtn.disabled = true;
+      issueBtn.title = isAlreadyIssued(status)
+        ? "Already issued — re-issue is not available"
+        : "Attendee is not eligible";
+    } else if (status === "not_issued") {
+      issueBtn.disabled = false;
+      issueBtn.title = "Issue credential to this attendee";
+    } else {
+      issueBtn.disabled = true;
+    }
+  }
+};
+
+const hydrateInputs = (root) => {
+  const { apiKey, badgeId, badgeName } = readConfig(root);
+  const apiKeyInput = root.querySelector("[data-credentials-api-key]");
+  const badgeIdInput = root.querySelector("[data-credentials-badge-id]");
+  if (apiKeyInput) apiKeyInput.value = apiKey;
+  if (badgeIdInput) badgeIdInput.value = badgeId;
+  syncSaveButton(root);
+  paintBadgeSummary(root, apiKey && badgeId ? badgeName : "");
+  return { apiKey, badgeId, badgeName };
+};
+
+const setSetupMsg = (root, message, isError = false) => {
+  const el = root.querySelector("[data-credentials-setup-msg]");
+  if (!el) return;
+  el.textContent = message || "";
+  el.className = isError
+    ? "text-xs text-red-600"
+    : "text-xs text-stone-500";
+};
+
+const refreshStatus = async (root) => {
+  const { apiKey, badgeId } = readInputValues(root);
+
+  if (!apiKey || !badgeId) {
+    setSetupMsg(root, "Enter both API key and badge ID, then save / refresh.", true);
+    return;
+  }
+
+  setSetupMsg(root, "Loading status from CertDirectory…");
+  const eventId = root.dataset.eventId;
+  try {
+    const response = await ocgFetch(
+      `/dashboard/group/events/${eventId}/credentials/status`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: cdHeaders(apiKey, badgeId),
+      },
+    );
+
+    if (!response.ok) {
+      const text = (await response.text()) || "Failed to load status";
+      setSetupMsg(root, text, true);
+      showErrorAlert(text);
+      return;
+    }
+
+    const rows = await response.json();
+    const byUser = new Map(rows.map((r) => [r.user_id, r]));
+    root.querySelectorAll("[data-credentials-row]").forEach((row) => {
+      const data = byUser.get(row.dataset.userId);
+      if (data) {
+        paintStatus(row, data.status, data.verify_url);
+      } else {
+        paintStatus(row, "not_issued", null);
+      }
+    });
+    setSetupMsg(root, "Status loaded.");
+  } catch (err) {
+    const message = err?.message || "Failed to load status";
+    setSetupMsg(root, message, true);
+    showErrorAlert(message);
+  }
+};
+
+/**
+ * Re-fetch the Credentials tab HTML (attendee list from OCG) then let init
+ * auto-load CertDirectory status. Needed so new RSVPs appear — status-only
+ * refresh can only paint rows that are already in the DOM.
+ */
+const reloadCredentialsPanel = async (root) => {
+  const eventId = root.dataset.eventId;
+  if (!eventId) return;
+
+  const { apiKey: key, badgeId: badge } = readInputValues(root);
+  const saved = readConfig(root);
+  if (key && badge) {
+    const sameAsSaved = key === saved.apiKey && badge === saved.badgeId;
+    writeConfig(root, key, badge, sameAsSaved ? saved.badgeName : "");
+  }
+
+  if (!window.htmx || typeof window.htmx.ajax !== "function") {
+    await refreshStatus(root);
+    return;
+  }
+
+  setSetupMsg(root, "Refreshing attendees and status…");
+  await window.htmx.ajax(
+    "GET",
+    `/dashboard/group/events/${eventId}/credentials`,
+    {
+      target: "#credentials-content",
+      swap: "innerHTML",
+      indicator: "#dashboard-spinner",
+    },
+  );
+};
+
+/** After HTMX history restore, re-hydrate and re-paint without re-binding. */
+const refreshAfterRestore = async (root) => {
+  if (!(root instanceof Element)) return;
+  hydrateInputs(root);
+  const { apiKey, badgeId } = readInputValues(root);
+  if (apiKey && badgeId) {
+    await refreshStatus(root);
+  }
+};
+
+const saveAndValidate = async (root) => {
+  const saveBtn = root.querySelector("[data-credentials-save]");
+  const { apiKey, badgeId } = readInputValues(root);
+
+  if (!apiKey || !badgeId) {
+    showErrorAlert("Enter both API key and badge ID.");
+    syncSaveButton(root);
+    return;
+  }
+
+  if (saveBtn) {
+    saveBtn.disabled = true;
+    saveBtn.textContent = "Validating…";
+  }
+  setSetupMsg(root, "Validating with CertDirectory…");
+
+  try {
+    const response = await ocgFetch(
+      `/dashboard/group/events/${root.dataset.eventId}/credentials/validate`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: cdHeaders(apiKey, badgeId),
+      },
+    );
+
+    if (!response.ok) {
+      const text = (await response.text()) || "Validation failed";
+      setSetupMsg(root, text, true);
+      showErrorAlert(text);
+      return;
+    }
+
+    const result = await response.json();
+    const badgeName = result.badge_name || "Unknown badge";
+    const inactiveNote = result.is_active
+      ? ""
+      : `<br><span class="text-amber-700">Note: this badge is currently inactive.</span>`;
+
+    const confirmed = await confirmAction({
+      message: `Save these CertDirectory settings?<br><br><strong>Badge:</strong> ${escapeHtml(badgeName)}${inactiveNote}`,
+      confirmText: "Save",
+      cancelText: "Cancel",
+      withHtml: true,
+    });
+
+    if (!confirmed) {
+      setSetupMsg(root, "Save cancelled.");
+      return;
+    }
+
+    writeConfig(root, apiKey, badgeId, badgeName);
+    paintBadgeSummary(root, badgeName);
+    setSetupMsg(root, `Saved — ${badgeName}`);
+    showSuccessAlert(`Saved. Badge: ${badgeName}`);
+    await refreshStatus(root);
+  } catch (err) {
+    const message = err?.message || "Validation failed";
+    setSetupMsg(root, message, true);
+    showErrorAlert(message);
+  } finally {
+    if (saveBtn) {
+      saveBtn.textContent = "Save to this browser";
+      syncSaveButton(root);
+    }
+  }
+};
+
+const issueOne = async (root, row) => {
+  const { apiKey, badgeId } = readInputValues(root);
+  const userId = row.dataset.userId;
+  const issueBtn = row.querySelector("[data-credentials-issue]");
+
+  if (!apiKey || !badgeId) {
+    showErrorAlert("Save your API key and badge ID first.");
+    return;
+  }
+
+  if (issueBtn) {
+    issueBtn.disabled = true;
+    issueBtn.textContent = "Issuing…";
+  }
+
+  try {
+    const response = await ocgFetch(
+      `/dashboard/group/events/${root.dataset.eventId}/attendees/${userId}/credentials/issue`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: cdHeaders(apiKey, badgeId),
+      },
+    );
+
+    if (!response.ok) {
+      const text = (await response.text()) || "Issue failed";
+      showErrorAlert(text);
+      if (issueBtn) {
+        issueBtn.disabled = false;
+        issueBtn.textContent = "Issue";
+      }
+      return;
+    }
+
+    const result = await response.json();
+    if (result.error) {
+      paintStatus(row, "failed", null);
+      showErrorAlert(result.error);
+      if (issueBtn) {
+        issueBtn.disabled = false;
+        issueBtn.textContent = "Issue";
+      }
+      return;
+    }
+
+    paintStatus(row, result.status || "issued", result.verify_url);
+    if (issueBtn) issueBtn.textContent = "Issue";
+    showSuccessAlert("Credential issued.");
+  } catch (err) {
+    showErrorAlert(err?.message || "Issue failed");
+    if (issueBtn) {
+      issueBtn.disabled = false;
+      issueBtn.textContent = "Issue";
+    }
+  }
+};
+
+const initCredentialsRoot = (root) => {
+  if (!(root instanceof Element) || !markDatasetReady(root, READY_KEY)) {
+    return;
+  }
+
+  if (root.dataset.canManage !== "true") {
+    hydrateInputs(root);
+    return;
+  }
+
+  const { apiKey, badgeId, badgeName } = hydrateInputs(root);
+
+  root
+    .querySelector("[data-credentials-api-key]")
+    ?.addEventListener("input", () => {
+      syncSaveButton(root);
+      syncBadgeSummaryVisibility(root);
+    });
+  root
+    .querySelector("[data-credentials-badge-id]")
+    ?.addEventListener("input", () => {
+      syncSaveButton(root);
+      syncBadgeSummaryVisibility(root);
+    });
+
+  root
+    .querySelector("[data-credentials-save]")
+    ?.addEventListener("click", () => {
+      void saveAndValidate(root);
+    });
+
+  root
+    .querySelector("[data-credentials-refresh]")
+    ?.addEventListener("click", () => {
+      void reloadCredentialsPanel(root);
+    });
+
+  root.querySelectorAll("[data-credentials-issue]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const row = btn.closest("[data-credentials-row]");
+      if (row) issueOne(root, row);
+    });
+  });
+
+  // Auto-load status (and badge name if missing) when both values are already saved.
+  if (apiKey && badgeId) {
+    void (async () => {
+      if (!badgeName) {
+        try {
+          const response = await ocgFetch(
+            `/dashboard/group/events/${root.dataset.eventId}/credentials/validate`,
+            {
+              method: "POST",
+              credentials: "same-origin",
+              headers: cdHeaders(apiKey, badgeId),
+            },
+          );
+          if (response.ok) {
+            const result = await response.json();
+            const name = result.badge_name || "";
+            if (name) {
+              writeConfig(root, apiKey, badgeId, name);
+              paintBadgeSummary(root, name);
+            }
+          }
+        } catch {
+          // Non-fatal — status refresh below still runs.
+        }
+      }
+      await refreshStatus(root);
+    })();
+  } else {
+    setSetupMsg(root, "Enter your API key and badge ID to get started.");
+  }
+};
+
+initializeOnReadyAndHtmxLoad((root, context = {}) => {
+  // History restore keeps dataset.credentialsReady, so init is skipped — still
+  // re-paint status so Issue buttons are not left disabled.
+  if (context.historyRestore) {
+    initializeMatchingRoots(root, ROOT_SELECTOR, (el) => {
+      void refreshAfterRestore(el);
+    });
+    return;
+  }
+  initializeMatchingRoots(root, ROOT_SELECTOR, initCredentialsRoot);
+});

--- a/ocg-server/templates/dashboard/group/credentials_list.html
+++ b/ocg-server/templates/dashboard/group/credentials_list.html
@@ -1,0 +1,176 @@
+{% import "macros/dashboard.html" as dashboard -%}
+{% import "macros/ui.html" as ui -%}
+
+{{ dashboard::form_title(
+     title = "Credentials",
+     description = "Issue CertDirectory credentials to event attendees without exposing their email addresses."
+) -}}
+
+<div id="credentials-root"
+     class="mt-6 space-y-6"
+     data-credentials-root
+     data-event-id="{{ event.event_id }}"
+     data-group-id="{{ group_id }}"
+     data-can-manage="{{ can_manage_events }}">
+
+  {# Setup card: API key (per group) + badge ID (per event), stored in this browser only. -#}
+  <section class="rounded-lg border border-stone-200 bg-white p-5"
+           data-credentials-setup>
+    <h3 class="text-sm font-semibold text-stone-900">CertDirectory setup</h3>
+    <p class="mt-1 text-sm text-stone-600">
+      Enter your
+      <a href="https://credentials.certdirectory.io/"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="font-medium text-primary-600 hover:text-primary-700 underline">CertDirectory</a>
+      API key and the badge ID for this event. Values are stored
+      <span class="font-medium">in this browser only</span> (localStorage) and sent to the
+      OCG server over HTTPS when you issue — they are never saved in the OCG database.
+      Issuing shares the attendee's name and email with CertDirectory, which emails them
+      the credential.
+    </p>
+    <div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div>
+        <label for="cd-api-key" class="block text-sm font-medium text-stone-900">API key</label>
+        <input id="cd-api-key"
+               type="password"
+               autocomplete="off"
+               spellcheck="false"
+               class="input-primary mt-1 w-full"
+               placeholder="crd_live_…"
+               data-credentials-api-key
+               {% if !can_manage_events -%} disabled {% endif -%}>
+      </div>
+      <div>
+        <label for="cd-badge-id" class="block text-sm font-medium text-stone-900">Badge ID</label>
+        <input id="cd-badge-id"
+               type="text"
+               autocomplete="off"
+               spellcheck="false"
+               class="input-primary mt-1 w-full font-mono text-sm"
+               placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+               data-credentials-badge-id
+               {% if !can_manage_events -%} disabled {% endif -%}>
+      </div>
+    </div>
+    <div class="mt-4 flex flex-wrap items-center gap-3">
+      {% if can_manage_events -%}
+        <button type="button"
+                class="btn-primary disabled:cursor-not-allowed disabled:opacity-50"
+                data-credentials-save
+                disabled
+                title="Enter both API key and badge ID">
+          Save to this browser
+        </button>
+        <button type="button"
+                class="btn-primary-outline"
+                data-credentials-refresh>
+          Load / refresh status
+        </button>
+      {% endif -%}
+      <p class="text-xs text-stone-500" data-credentials-setup-msg></p>
+    </div>
+    {# Shown after a successful save (badge name from CertDirectory). -#}
+    <div class="mt-4 hidden rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3"
+         data-credentials-badge-summary>
+      <p class="text-sm text-emerald-900">
+        <span class="font-medium">Issuing badge:</span>
+        <span data-credentials-badge-name></span>
+      </p>
+      <p class="mt-0.5 text-xs text-emerald-800/80">
+        Attendees will receive this CertDirectory credential when you click Issue.
+      </p>
+    </div>
+  </section>
+
+  {# Attendee list with live status pills (filled by JS). -#}
+  <section>
+    <div class="mb-3 flex items-center justify-between gap-3">
+      <h3 class="text-sm font-semibold text-stone-900">
+        Attendees
+        <span class="font-normal text-stone-500">({{ total }})</span>
+      </h3>
+    </div>
+
+    {% if attendees.is_empty() -%}
+      <p class="rounded-lg border border-dashed border-stone-200 bg-stone-50 px-4 py-8 text-center text-sm text-stone-500">
+        No attendees for this event yet.
+      </p>
+    {% else -%}
+      <div class="overflow-x-auto rounded-lg border border-stone-200">
+        <table class="min-w-full divide-y divide-stone-200 text-sm">
+          <thead class="bg-stone-50">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left font-semibold text-stone-700">Attendee</th>
+              <th scope="col" class="px-4 py-3 text-left font-semibold text-stone-700">Status</th>
+              <th scope="col" class="px-4 py-3 text-right font-semibold text-stone-700">Action</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-stone-100 bg-white">
+            {% for attendee in attendees -%}
+              <tr data-credentials-row
+                  data-user-id="{{ attendee.user.user_id }}"
+                  data-eligible="{{ attendee.can_receive_attendee_email }}">
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-3">
+                    <div class="flex size-8 shrink-0 items-center justify-center rounded-full bg-stone-100 text-xs font-semibold text-stone-600">
+                      {{ self::user_initials(attendee.user.name.as_deref(), attendee.user.username.as_str()) }}
+                    </div>
+                    <div class="min-w-0">
+                      <div class="truncate font-medium text-stone-900">
+                        {% if let Some(name) = attendee.user.name.as_ref() -%}
+                          {{ name }}
+                        {% else -%}
+                          {{ attendee.user.username }}
+                        {% endif -%}
+                      </div>
+                      <div class="truncate text-xs text-stone-500">@{{ attendee.user.username }}</div>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  <span class="inline-flex items-center rounded-full bg-stone-100 px-2.5 py-0.5 text-xs font-medium text-stone-600"
+                        data-credentials-status>
+                    —
+                  </span>
+                  <a href="#"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     class="ml-2 hidden text-xs font-medium text-primary-600 hover:text-primary-700"
+                     data-credentials-verify>
+                    Verify →
+                  </a>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  {% if can_manage_events -%}
+                    {% if attendee.can_receive_attendee_email -%}
+                      <button type="button"
+                              class="btn-primary text-xs px-3 py-1.5 disabled:cursor-not-allowed disabled:opacity-50"
+                              data-credentials-issue
+                              disabled
+                              title="Save API key + badge ID and refresh status first">
+                        Issue
+                      </button>
+                    {% else -%}
+                      <span class="text-xs text-stone-400"
+                            title="Attendee has not opted in to email / is not eligible">
+                        Not eligible
+                      </span>
+                    {% endif -%}
+                  {% else -%}
+                    <span class="text-xs text-stone-400">—</span>
+                  {% endif -%}
+                </td>
+              </tr>
+            {% endfor -%}
+          </tbody>
+        </table>
+      </div>
+      <p class="mt-2 text-xs text-stone-500">
+        Opening this tab or clicking Load / refresh status reloads attendees from OCG
+        and status from CertDirectory. The Issue button is disabled once a credential
+        already exists for that attendee (any status).
+      </p>
+    {% endif -%}
+  </section>
+</div>

--- a/ocg-server/templates/dashboard/group/events_update.html
+++ b/ocg-server/templates/dashboard/group/events_update.html
@@ -151,6 +151,7 @@
           {{ event_form::tab_option(section = "invitation-requests", label = "Requests") -}}
         {% endif -%}
         {{ event_form::tab_option(section = "waitlist", label = "Waitlist") -}}
+        {{ event_form::tab_option(section = "credentials", label = "Credentials") -}}
       </select>
       <ul class="hidden flex-col gap-1 font-medium xl:flex">
         {{ event_form::tab_button(section = "details", icon = "event", label = "Details", active = true) -}}
@@ -172,6 +173,9 @@
   {% endif -%}
   {% let waitlist_attrs -%}hx-get="/dashboard/group/events/{{ event.event_id }}/waitlist" hx-trigger="click once" hx-target="#waitlist-content" hx-swap="innerHTML" hx-indicator="#waitlist-loading"{%- endlet %}
 {{ event_form::tab_button(section = "waitlist", icon = "waitlist", label = "Waitlist", extra_attrs = waitlist_attrs) -}}
+  {# Reload on every open (not "once") so attendees + status stay fresh when returning. -#}
+  {% let credentials_attrs -%}hx-get="/dashboard/group/events/{{ event.event_id }}/credentials" hx-trigger="click" hx-target="#credentials-content" hx-swap="innerHTML" hx-indicator="#dashboard-spinner"{%- endlet %}
+{{ event_form::tab_button(section = "credentials", icon = "star", label = "Credentials", extra_attrs = credentials_attrs) -}}
 </ul>
 </aside>
 
@@ -1065,6 +1069,21 @@
   </div>
 </div>
 {# End Waitlist Tab -#}
+
+{# Credentials Tab -#}
+<div data-content="credentials"
+     class="hidden min-w-0 px-4 xl:col-start-2 xl:px-0">
+  <div id="credentials-content">
+    {{ dashboard::form_title(title = "Credentials", description = "Issue CertDirectory credentials to event attendees.") -}}
+    <div id="credentials-loading" class="flex items-center justify-center py-12">
+      <div class="flex flex-col items-center space-y-4">
+        {{ ui::spinner(size = "size-10") -}}
+        <div class="text-sm text-stone-500">Loading credentials...</div>
+      </div>
+    </div>
+  </div>
+</div>
+{# End Credentials Tab -#}
 
 {# Form buttons -#}
 <div class="flex flex-wrap items-center justify-end gap-3 mt-6 px-4 xl:col-start-2 xl:px-0">

--- a/ocg-server/templates/dashboard/group/home.html
+++ b/ocg-server/templates/dashboard/group/home.html
@@ -23,6 +23,7 @@
   <script type="module"
           src="/static/js/dashboard/group/event-selector/selector.js"></script>
   <script type="module" src="/static/js/dashboard/group/attendees.js"></script>
+  <script type="module" src="/static/js/dashboard/group/credentials.js"></script>
   <script type="module" src="/static/js/dashboard/group/event-add.js"></script>
   <script type="module" src="/static/js/dashboard/group/event-update.js"></script>
   <script type="module" src="/static/js/dashboard/group/events-list.js"></script>


### PR DESCRIPTION
## Summary

- Adds a **Credentials** sub-tab on the group event dashboard so organizers can issue digital badges/credentials to attendees from inside OCG.
- **Stateless design:** no OCG database/schema changes. API key (per group) and badge ID (per event) live in browser `localStorage`; attendee emails are resolved only on the server; issuance status is derived live from the external issuer.
- First adapter: [CertDirectory](https://credentials.certdirectory.io), the CNCF Community Groups credential provider ([commitment letter](https://github.com/certdirectory/certdirectory-platform-docs/blob/main/docs/CNCF_Commitment_Letter.pdf)).

Closes https://github.com/cncf/open-community-groups/issues/611
<img width="1487" height="847" alt="Screenshot 2026-07-22 at 4 42 53 pm" src="https://github.com/user-attachments/assets/9a246d9e-06fd-45d9-8bab-3bf43e090b65" />


## What's included

- Setup: validate API key + badge ID, confirm badge name, save in this browser
- Attendee table with live status (`Not issued` / `Pending` / `Issued` / `Expired` / `Revoked`)
- Per-row **Issue** (disabled once any credential exists for that attendee + badge)
- Tab open / **Load / refresh status** reloads attendees from OCG and re-derives issuer status (new RSVPs appear)
- Optional `credentials.base_url` in server config (defaults to production CertDirectory)

## Privacy

- Issue only when `can_receive_attendee_email` is true
- Browser never receives attendee emails (responses use `user_id` + status)
- API keys are not stored in OCG
- UI discloses that issuing shares name + email with the credential provider



## Test plan

This was tested locally end-to-end against CertDirectory and is working as expected.

- [x] As an organizer with `EventsWrite`, open an event → **Credentials** tab
- [x] Enter CertDirectory API key + badge ID → Save → confirm badge name is shown
- [x] Status pills load; **Issue** enabled only for eligible, not-yet-issued attendees
- [x] Issue one attendee → status updates; button disables; recipient receives email
- [x] Leave the tab / event and return → status auto-refreshes; Issue buttons correct
- [x] New RSVP while on the tab → **Load / refresh status** shows the new attendee
- [ ] Confirm no files under `database/migrations/` are changed
- [ ] `just server-fmt-and-lint` (and frontend lint if applicable)